### PR TITLE
feat: add email auth and protect routes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,21 +8,41 @@
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
 </head>
 <body>
-    <header>
+    <header style="display:none;">
         <h1>Minha Estética</h1>
         <nav id="main-nav">
             <a href="#dashboard">Dashboard</a>
             <a href="#agenda">Agenda</a>
             <a href="#clientes">Clientes</a>
             <a href="#servicos">Serviços</a>
+            <span id="whoami" class="muted"></span>
+            <button id="btnSignOut" class="link">Sair</button>
         </nav>
     </header>
 
-    <main id="app-container">
-        </main>
+    <section id="login-view" class="card" style="display:none;max-width:360px;margin:40px auto;">
+        <h2>Entrar</h2>
+        <form id="login-form" class="grid mt">
+            <label>Email <input id="login-email" type="email" required /></label>
+            <label>Senha <input id="login-pass" type="password" required /></label>
+            <button class="btn btn-primary">Entrar</button>
+        </form>
+        <details class="mt">
+            <summary>Criar conta</summary>
+            <form id="signup-form" class="grid mt">
+                <label>Email <input id="signup-email" type="email" required /></label>
+                <label>Senha <input id="signup-pass" type="password" required /></label>
+                <button class="btn">Criar</button>
+            </form>
+        </details>
+        <p class="mt"><a href="#" id="reset-link">Esqueci a senha</a></p>
+    </section>
+
+    <main id="app-container"></main>
 
     <div id="modal-placeholder"></div>
 
+    <script type="module" src="js/auth.js"></script>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,0 +1,103 @@
+import { auth } from './firebase-config.js';
+import { navigate } from './router.js';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  sendPasswordResetEmail,
+  signOut as firebaseSignOut,
+  onAuthStateChanged
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+
+export function signIn(email, pass) {
+  return signInWithEmailAndPassword(auth, email, pass);
+}
+
+export function signUp(email, pass) {
+  return createUserWithEmailAndPassword(auth, email, pass);
+}
+
+export function sendReset(email) {
+  return sendPasswordResetEmail(auth, email);
+}
+
+export function signOut() {
+  return firebaseSignOut(auth);
+}
+
+const header = document.querySelector('header');
+const loginView = document.getElementById('login-view');
+const whoami = document.getElementById('whoami');
+const appContainer = document.getElementById('app-container');
+
+// Listeners for forms
+const loginForm = document.getElementById('login-form');
+if (loginForm) {
+  loginForm.onsubmit = async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('login-email').value.trim();
+    const pass = document.getElementById('login-pass').value.trim();
+    try {
+      await signIn(email, pass);
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+}
+
+const signupForm = document.getElementById('signup-form');
+if (signupForm) {
+  signupForm.onsubmit = async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('signup-email').value.trim();
+    const pass = document.getElementById('signup-pass').value.trim();
+    try {
+      await signUp(email, pass);
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+}
+
+const resetLink = document.getElementById('reset-link');
+if (resetLink) {
+  resetLink.onclick = async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('login-email').value.trim();
+    if (!email) {
+      alert('Informe o email para reset.');
+      return;
+    }
+    try {
+      await sendReset(email);
+      alert('Email de redefinição enviado.');
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+}
+
+const btnSignOut = document.getElementById('btnSignOut');
+if (btnSignOut) {
+  btnSignOut.onclick = () => signOut();
+}
+
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    whoami.textContent = user.email;
+    header.style.display = '';
+    loginView.style.display = 'none';
+    if (location.hash === '#login' || !location.hash) {
+      location.hash = '#dashboard';
+    }
+    navigate();
+  } else {
+    whoami.textContent = '';
+    header.style.display = 'none';
+    loginView.style.display = '';
+    appContainer.innerHTML = '';
+    if (location.hash !== '#login') {
+      location.hash = '#login';
+    }
+  }
+});
+

--- a/public/js/firebase-config.js
+++ b/public/js/firebase-config.js
@@ -16,8 +16,6 @@ const firebaseConfig = {
 };
 
 // Inicialize o Firebase
-const app = initializeApp(firebaseConfig);
-
-// Exporte os serviços para serem usados em outros módulos
+export const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
-export const auth = getAuth(app);
+export const auth = typeof window !== 'undefined' ? getAuth(app) : null;

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -2,6 +2,7 @@
 import { renderClientesView } from './views/clientesView.js';
 import { renderServicosView } from './views/servicosView.js';
 import { renderAgendaView } from './views/agendaView.js';
+import { auth } from './firebase-config.js';
 
 const appContainer = document.getElementById('app-container');
 
@@ -29,6 +30,21 @@ const routes = {
 
 export const navigate = () => {
   const hash = location.hash || '#dashboard';
+
+  if (!auth.currentUser && hash !== '#login') {
+    location.hash = '#login';
+    return;
+  }
+  if (auth.currentUser && hash === '#login') {
+    location.hash = '#dashboard';
+    return;
+  }
+
+  if (hash === '#login') {
+    appContainer.innerHTML = '';
+    return;
+  }
+
   const [mainPath, param] = hash.split('/');
 
   // link ativo


### PR DESCRIPTION
## Summary
- add Firebase auth module for sign in, sign up and reset password
- guard routes and show login screen for anonymous users
- display signed in user and sign out option in navbar

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/brancofilm/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689bf7949104832e829afb006cd6ab7e