### PR TITLE
Revamp authentication UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gestão Estética Automotiva</title>
-    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="styles.css">
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
 </head>
 <body>
-    <header style="display:none;">
+    <header>
         <h1>Minha Estética</h1>
-        <nav id="main-nav">
+        <nav id="main-nav" style="display:none;">
             <a href="#dashboard">Dashboard</a>
             <a href="#agenda">Agenda</a>
             <a href="#clientes">Clientes</a>
@@ -20,23 +20,70 @@
         </nav>
     </header>
 
-    <section id="login-view" class="card" style="display:none;max-width:360px;margin:40px auto;">
-        <h2>Entrar</h2>
-        <form id="login-form" class="grid mt">
-            <label>Email <input id="login-email" type="email" required /></label>
-            <label>Senha <input id="login-pass" type="password" required /></label>
-            <button class="btn btn-primary">Entrar</button>
-        </form>
-        <details class="mt">
-            <summary>Criar conta</summary>
-            <form id="signup-form" class="grid mt">
-                <label>Email <input id="signup-email" type="email" required /></label>
-                <label>Senha <input id="signup-pass" type="password" required /></label>
-                <button class="btn">Criar</button>
+    <div class="auth-shell" style="display:none;">
+        <div class="auth-card">
+            <div class="tabs">
+                <button id="tab-signin" class="tab-btn" role="tab" aria-selected="true">Entrar</button>
+                <button id="tab-signup" class="tab-btn" role="tab" aria-selected="false">Criar conta</button>
+            </div>
+            <div id="auth-alert" class="alert" aria-live="polite"></div>
+
+            <form id="signin-form" class="grid mt" aria-busy="false">
+                <div class="input-group">
+                    <label for="signin-email">Email</label>
+                    <input id="signin-email" type="email" class="input" required />
+                </div>
+                <div class="input-group">
+                    <label for="signin-pass">Senha</label>
+                    <div class="password-field">
+                        <input id="signin-pass" type="password" class="input" required />
+                        <button type="button" class="show-pass-btn" aria-label="Mostrar senha">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                        </button>
+                    </div>
+                </div>
+                <label class="checkbox"><input type="checkbox" id="remember-me" /> Lembrar de mim</label>
+                <button type="submit" class="btn btn-primary">
+                    <span class="btn-label">Entrar</span>
+                    <span class="spinner" hidden></span>
+                </button>
             </form>
-        </details>
-        <p class="mt"><a href="#" id="reset-link">Esqueci a senha</a></p>
-    </section>
+
+            <form id="signup-form" class="grid mt" hidden aria-busy="false">
+                <div class="input-group">
+                    <label for="signup-email">Email</label>
+                    <input id="signup-email" type="email" class="input" required />
+                </div>
+                <div class="input-group">
+                    <label for="signup-pass">Senha</label>
+                    <div class="password-field">
+                        <input id="signup-pass" type="password" class="input" required minlength="6" />
+                        <button type="button" class="show-pass-btn" aria-label="Mostrar senha">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                        </button>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-primary">
+                    <span class="btn-label">Criar</span>
+                    <span class="spinner" hidden></span>
+                </button>
+            </form>
+
+            <form id="reset-form" class="grid mt" hidden aria-busy="false">
+                <div class="input-group">
+                    <label for="reset-email">Email</label>
+                    <input id="reset-email" type="email" class="input" required />
+                </div>
+                <button type="submit" class="btn btn-primary">
+                    <span class="btn-label">Enviar</span>
+                    <span class="spinner" hidden></span>
+                </button>
+                <button type="button" id="back-to-login" class="btn btn-secondary">Voltar</button>
+            </form>
+
+            <p class="mt"><a href="#" id="link-reset" class="link">Esqueci a senha</a></p>
+        </div>
+    </div>
 
     <main id="app-container"></main>
 
@@ -46,3 +93,4 @@
     <script type="module" src="js/main.js"></script>
 </body>
 </html>
+

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -20,80 +20,173 @@ export function sendReset(email) {
   return sendPasswordResetEmail(auth, email);
 }
 
-export function signOut() {
+export function signOutUser() {
   return firebaseSignOut(auth);
 }
 
+const authShell = document.querySelector('.auth-shell');
+const authAlert = document.getElementById('auth-alert');
+const signinForm = document.getElementById('signin-form');
+const signupForm = document.getElementById('signup-form');
+const resetForm = document.getElementById('reset-form');
+const tabSignin = document.getElementById('tab-signin');
+const tabSignup = document.getElementById('tab-signup');
+const linkReset = document.getElementById('link-reset');
+const backToLogin = document.getElementById('back-to-login');
+const showPassBtns = document.querySelectorAll('.show-pass-btn');
+
 const header = document.querySelector('header');
-const loginView = document.getElementById('login-view');
+const nav = document.getElementById('main-nav');
 const whoami = document.getElementById('whoami');
 const appContainer = document.getElementById('app-container');
-
-// Listeners for forms
-const loginForm = document.getElementById('login-form');
-if (loginForm) {
-  loginForm.onsubmit = async (e) => {
-    e.preventDefault();
-    const email = document.getElementById('login-email').value.trim();
-    const pass = document.getElementById('login-pass').value.trim();
-    try {
-      await signIn(email, pass);
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-}
-
-const signupForm = document.getElementById('signup-form');
-if (signupForm) {
-  signupForm.onsubmit = async (e) => {
-    e.preventDefault();
-    const email = document.getElementById('signup-email').value.trim();
-    const pass = document.getElementById('signup-pass').value.trim();
-    try {
-      await signUp(email, pass);
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-}
-
-const resetLink = document.getElementById('reset-link');
-if (resetLink) {
-  resetLink.onclick = async (e) => {
-    e.preventDefault();
-    const email = document.getElementById('login-email').value.trim();
-    if (!email) {
-      alert('Informe o email para reset.');
-      return;
-    }
-    try {
-      await sendReset(email);
-      alert('Email de redefinição enviado.');
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-}
-
 const btnSignOut = document.getElementById('btnSignOut');
-if (btnSignOut) {
-  btnSignOut.onclick = () => signOut();
+
+function mapError(code) {
+  const map = {
+    'auth/invalid-email': 'Email inválido.',
+    'auth/user-disabled': 'Usuário desativado.',
+    'auth/user-not-found': 'Usuário não encontrado.',
+    'auth/wrong-password': 'Senha incorreta.',
+    'auth/email-already-in-use': 'Email já cadastrado.',
+    'auth/weak-password': 'Senha fraca. Use pelo menos 6 caracteres.',
+    'auth/missing-password': 'Informe a senha.'
+  };
+  return map[code] || 'Ocorreu um erro. Tente novamente.';
 }
+
+function showAlert(type, msg) {
+  authAlert.textContent = msg;
+  authAlert.className = `alert ${type}`;
+  authAlert.style.display = 'block';
+}
+
+function clearAlert() {
+  authAlert.textContent = '';
+  authAlert.className = 'alert';
+  authAlert.style.display = 'none';
+}
+
+function setBusy(form, busy) {
+  form.setAttribute('aria-busy', busy);
+  const elements = form.querySelectorAll('input, button');
+  elements.forEach(el => (el.disabled = busy));
+  const spinner = form.querySelector('.spinner');
+  if (spinner) spinner.hidden = !busy;
+}
+
+function toggleTab(name) {
+  clearAlert();
+  if (name === 'signin') {
+    tabSignin.setAttribute('aria-selected', 'true');
+    tabSignup.setAttribute('aria-selected', 'false');
+    signinForm.hidden = false;
+    signupForm.hidden = true;
+    resetForm.hidden = true;
+    if (linkReset) linkReset.style.display = '';
+  } else if (name === 'signup') {
+    tabSignin.setAttribute('aria-selected', 'false');
+    tabSignup.setAttribute('aria-selected', 'true');
+    signinForm.hidden = true;
+    signupForm.hidden = false;
+    resetForm.hidden = true;
+    if (linkReset) linkReset.style.display = 'none';
+  } else if (name === 'reset') {
+    tabSignin.setAttribute('aria-selected', 'false');
+    tabSignup.setAttribute('aria-selected', 'false');
+    signinForm.hidden = true;
+    signupForm.hidden = true;
+    resetForm.hidden = false;
+    if (linkReset) linkReset.style.display = 'none';
+  }
+}
+
+tabSignin?.addEventListener('click', () => toggleTab('signin'));
+tabSignup?.addEventListener('click', () => toggleTab('signup'));
+linkReset?.addEventListener('click', (e) => {
+  e.preventDefault();
+  toggleTab('reset');
+});
+backToLogin?.addEventListener('click', () => toggleTab('signin'));
+
+showPassBtns.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const input = btn.parentElement?.querySelector('input');
+    if (!input) return;
+    const isPassword = input.type === 'password';
+    input.type = isPassword ? 'text' : 'password';
+    btn.innerHTML = isPassword
+      ? '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a20.29 20.29 0 0 1 5.06-5.94M9.9 4.24A10.94 10.94 0 0 1 12 5c7 0 11 7 11 7a20.29 20.29 0 0 1-4.06 4.94"/><line x1="1" y1="1" x2="23" y2="23"/></svg>'
+      : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>';
+  });
+});
+
+signinForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  clearAlert();
+  const email = document.getElementById('signin-email').value.trim();
+  const pass = document.getElementById('signin-pass').value;
+  setBusy(signinForm, true);
+  try {
+    await signIn(email, pass);
+    location.hash = '#dashboard';
+  } catch (err) {
+    showAlert('error', mapError(err.code));
+  } finally {
+    setBusy(signinForm, false);
+  }
+});
+
+signupForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  clearAlert();
+  const email = document.getElementById('signup-email').value.trim();
+  const pass = document.getElementById('signup-pass').value;
+  if (pass.length < 6) {
+    showAlert('error', 'Senha deve ter ao menos 6 caracteres.');
+    return;
+  }
+  setBusy(signupForm, true);
+  try {
+    await signUp(email, pass);
+    location.hash = '#dashboard';
+  } catch (err) {
+    showAlert('error', mapError(err.code));
+  } finally {
+    setBusy(signupForm, false);
+  }
+});
+
+resetForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  clearAlert();
+  const email = document.getElementById('reset-email').value.trim();
+  setBusy(resetForm, true);
+  try {
+    await sendReset(email);
+    showAlert('success', 'Email de redefinição enviado.');
+    toggleTab('signin');
+  } catch (err) {
+    showAlert('error', mapError(err.code));
+  } finally {
+    setBusy(resetForm, false);
+  }
+});
+
+btnSignOut?.addEventListener('click', () => signOutUser());
 
 onAuthStateChanged(auth, (user) => {
   if (user) {
     whoami.textContent = user.email;
-    header.style.display = '';
-    loginView.style.display = 'none';
+    nav.style.display = '';
+    authShell.style.display = 'none';
     if (location.hash === '#login' || !location.hash) {
       location.hash = '#dashboard';
     }
     navigate();
   } else {
     whoami.textContent = '';
-    header.style.display = 'none';
-    loginView.style.display = '';
+    nav.style.display = 'none';
+    authShell.style.display = '';
     appContainer.innerHTML = '';
     if (location.hash !== '#login') {
       location.hash = '#login';

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -1,4 +1,3 @@
-// js/router.js
 import { renderClientesView } from './views/clientesView.js';
 import { renderServicosView } from './views/servicosView.js';
 import { renderAgendaView } from './views/agendaView.js';
@@ -6,7 +5,7 @@ import { auth } from './firebase-config.js';
 
 const appContainer = document.getElementById('app-container');
 
-const renderDashboardView = () => {
+function renderDashboardView() {
   appContainer.innerHTML = `
     <section class="card">
       <h2>Dashboard</h2>
@@ -19,7 +18,7 @@ const renderDashboardView = () => {
       </div>
     </section>
   `;
-};
+}
 
 const routes = {
   '#dashboard': renderDashboardView,
@@ -28,13 +27,14 @@ const routes = {
   '#servicos': renderServicosView,
 };
 
-export const navigate = () => {
+export function navigate() {
   const hash = location.hash || '#dashboard';
 
   if (!auth.currentUser && hash !== '#login') {
     location.hash = '#login';
     return;
   }
+
   if (auth.currentUser && hash === '#login') {
     location.hash = '#dashboard';
     return;
@@ -47,7 +47,6 @@ export const navigate = () => {
 
   const [mainPath, param] = hash.split('/');
 
-  // link ativo
   const navLinks = document.querySelectorAll('#main-nav a');
   navLinks.forEach(link => link.classList.remove('active'));
   const activeLink = document.querySelector(`#main-nav a[href^="${mainPath}"]`);
@@ -59,4 +58,5 @@ export const navigate = () => {
   } else {
     renderDashboardView();
   }
-};
+}
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,14 +1,25 @@
 /* --- RESET E ESTILOS GLOBAIS --- */
+:root {
+    --brand: #0f172a;
+    --bg: #f6f7f8;
+    --card: #fff;
+    --muted: #6b7280;
+    --border: #e5e7eb;
+    --primary: #111;
+    --primary-contrast: #fff;
+    --ring: #2563eb;
+}
+
 * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
 body {
-    background-color: #f0f2f5; /* Um cinza claro para o fundo */
-    color: #1c1e21; /* Cor de texto principal */
+    background-color: var(--bg);
+    color: var(--primary);
 }
 
 /* --- CABEÇALHO E NAVEGAÇÃO --- */
@@ -258,4 +269,160 @@ main#app-container {
 /* Cor do evento no calendário */
 .fc-event {
     cursor: pointer;
+}
+
+/* --- NOVOS ESTILOS DE AUTENTICAÇÃO --- */
+.auth-shell {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+}
+
+.auth-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    padding: 24px;
+    width: 100%;
+    max-width: 420px;
+}
+
+.tabs {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.tab-btn {
+    flex: 1;
+    background: none;
+    border: none;
+    padding: 0.5rem;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+}
+
+.tab-btn[aria-selected="true"] {
+    border-color: var(--primary);
+    font-weight: 600;
+}
+
+.input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.input {
+    width: 100%;
+    height: 40px;
+    padding: 0 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--card);
+}
+
+.input:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+}
+
+.password-field {
+    position: relative;
+}
+
+.show-pass-btn {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+}
+
+.alert {
+    display: none;
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+}
+
+.alert.success {
+    background: #d1fae5;
+    color: #065f46;
+}
+
+.alert.error {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    height: 40px;
+    padding: 0 1rem;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.btn-primary {
+    width: 100%;
+    background: var(--primary);
+    color: var(--primary-contrast);
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+    filter: brightness(0.9);
+}
+
+.btn-primary:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.btn-secondary {
+    background: transparent;
+    color: var(--primary);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+    background: var(--border);
+}
+
+.spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--primary-contrast);
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.mt {
+    margin-top: 1rem;
+}
+
+.muted {
+    color: var(--muted);
 }


### PR DESCRIPTION
## Summary
- redesign login into tabbed auth card with signup and reset flows
- add theme variables and responsive auth styles
- update auth and router logic for gated navigation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bf9806650832e8550fe88cd31d1b1