### PR TITLE
feat: add service orders and agenda

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gestão Estética Automotiva</title>
     <link rel="stylesheet" href="styles.css">
-    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.min.css">
 </head>
 <body>
     <header>
@@ -13,6 +13,7 @@
         <nav id="main-nav" style="display:none;">
             <a href="#dashboard">Dashboard</a>
             <a href="#agenda">Agenda</a>
+            <a href="#orders">Ordens</a>
             <a href="#clientes">Clientes</a>
             <a href="#servicos">Serviços</a>
             <span id="whoami" class="muted"></span>
@@ -97,6 +98,7 @@
 
     <script type="module" src="js/auth.js"></script>
     <script type="module" src="js/main.js"></script>
+    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
 </body>
 </html>
 

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -1,6 +1,7 @@
 import { renderClientesView } from './views/clientesView.js';
 import { renderServicosView } from './views/servicosView.js';
 import { renderAgendaView } from './views/agendaView.js';
+import { renderOrdersView } from './views/ordersView.js';
 import { auth } from './firebase-config.js';
 
 const appContainer = document.getElementById('app-container');
@@ -25,6 +26,7 @@ const routes = {
   '#agenda': renderAgendaView,
   '#clientes': renderClientesView,
   '#servicos': renderServicosView,
+  '#orders': renderOrdersView,
 };
 
 export function navigate() {

--- a/public/js/services/firestoreService.js
+++ b/public/js/services/firestoreService.js
@@ -11,8 +11,8 @@ import {
 // --- Coleções ---
 const customersCollection = collection(db, 'customers');
 const vehiclesCollection  = collection(db, 'vehicles');
-const servicosCollection  = collection(db, 'servicos');
-const serviceOrdersCollection = collection(db, 'serviceOrders');
+const servicosCollection  = collection(db, 'services');
+const ordersCollection    = collection(db, 'orders');
 
 // --- Clientes ---
 export async function getCustomers(opts = {}) {
@@ -72,34 +72,72 @@ export function deleteVehicle(id) {
 
 // --- Serviços ---
 export async function getServicos() {
-  const snap = await getDocs(servicosCollection);
+  const q = query(servicosCollection, orderBy('createdAt', 'desc'));
+  const snap = await getDocs(q);
   return snap.docs.map(d => ({ id: d.id, ...d.data() }));
 }
-export function addServico(name, price) {
-  return addDoc(servicosCollection, { name, price: Number(price)||0, createdAt: serverTimestamp() });
+export function addServico({ name, price }) {
+  return addDoc(servicosCollection, {
+    name,
+    price: Number(price) || 0,
+    createdAt: serverTimestamp()
+  });
 }
 export async function getServicoById(id) {
-  const dref = await getDoc(doc(db, 'servicos', id));
+  const dref = await getDoc(doc(servicosCollection, id));
   return dref.exists() ? { id: dref.id, ...dref.data() } : null;
 }
 export function updateServico(id, data) {
-  return updateDoc(doc(db, 'servicos', id), data);
+  return updateDoc(doc(servicosCollection, id), data);
 }
 export function deleteServico(id) {
-  return deleteDoc(doc(db, 'servicos', id));
+  return deleteDoc(doc(servicosCollection, id));
 }
 
-// --- Ordens (Agenda) ---
-export async function getServiceOrders() {
-  const snap = await getDocs(serviceOrdersCollection);
-  return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+// --- Ordens de Serviço ---
+export async function getOrders(opts = {}) {
+  const { status, from, to, limit: limitCount, startAfterId } = opts;
+  let q = ordersCollection;
+
+  if (status) q = query(q, where('status', '==', status));
+  if (from)   q = query(q, where('scheduledStart', '>=', from));
+  if (to)     q = query(q, where('scheduledStart', '<=', to));
+
+  if (from || to) {
+    q = query(q, orderBy('scheduledStart', 'asc'));
+  } else {
+    q = query(q, orderBy('createdAt', 'desc'));
+  }
+
+  if (startAfterId) {
+    const startDoc = await getDoc(doc(ordersCollection, startAfterId));
+    if (startDoc.exists()) q = query(q, startAfter(startDoc));
+  }
+  if (limitCount) q = query(q, limitFn(limitCount));
+
+  const snap = await getDocs(q);
+  const arr = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  arr.lastId = snap.docs.length ? snap.docs[snap.docs.length - 1].id : null;
+  return arr;
 }
-export function addServiceOrder(data) {
-  return addDoc(serviceOrdersCollection, { ...data, createdAt: serverTimestamp() });
+export async function getOrderById(id) {
+  const dref = await getDoc(doc(ordersCollection, id));
+  return dref.exists() ? { id: dref.id, ...dref.data() } : null;
 }
-export function updateServiceOrder(id, data) {
-  return updateDoc(doc(db, 'serviceOrders', id), data);
+export async function addOrder(data) {
+  const res = await addDoc(ordersCollection, {
+    ...data,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+  return res.id;
 }
-export function deleteServiceOrder(id) {
-  return deleteDoc(doc(db, 'serviceOrders', id));
+export function updateOrder(id, data) {
+  return updateDoc(doc(ordersCollection, id), {
+    ...data,
+    updatedAt: serverTimestamp(),
+  });
+}
+export function deleteOrder(id) {
+  return deleteDoc(doc(ordersCollection, id));
 }

--- a/public/js/views/agendaView.js
+++ b/public/js/views/agendaView.js
@@ -1,5 +1,5 @@
 // js/views/agendaView.js
-import { getServiceOrders, addServiceOrder, updateServiceOrder, deleteServiceOrder, getCustomers, getServicos } from '../services/firestoreService.js';
+import { getOrders, addOrder, updateOrder, getCustomers, getCustomerById, getVehiclesForCustomer, getServicos } from '../services/firestoreService.js';
 import { Timestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
 const appContainer = document.getElementById('app-container');
@@ -9,97 +9,113 @@ let calendar;
 export const renderAgendaView = async () => {
   appContainer.innerHTML = `
     <section>
-      <h2>Agenda de Serviços</h2>
+      <h2>Agenda</h2>
       <div id="calendar-container" class="card" style="padding:8px"></div>
       <div class="mt"><button class="btn" id="btnNewEvent">Novo agendamento</button></div>
     </section>
   `;
-
-  const { Calendar } = window; // FullCalendar já está no index.html
-  const orders = await getServiceOrders();
-  const events = orders.map(o => ({
+  const orders = await getOrders();
+  const customers = {};
+  for (const o of orders) {
+    if (!customers[o.customerId]) {
+      customers[o.customerId] = (await getCustomerById(o.customerId))?.name || '';
+    }
+  }
+  const events = orders.filter(o=>o.scheduledStart).map(o => ({
     id: o.id,
-    title: o.title || 'Serviço',
-    start: o.start?.seconds ? new Date(o.start.seconds*1000) : (o.start || null),
-    end:   o.end?.seconds   ? new Date(o.end.seconds*1000)   : (o.end   || null),
+    title: `${customers[o.customerId] || ''} - ${o.items?.[0]?.name || ''}`,
+    start: o.scheduledStart.seconds ? new Date(o.scheduledStart.seconds*1000) : o.scheduledStart,
+    end: o.scheduledEnd?.seconds ? new Date(o.scheduledEnd.seconds*1000) : (o.scheduledEnd || null)
   }));
-
-  const el = document.getElementById('calendar-container');
-  calendar = new Calendar(el, {
+  const { Calendar } = window;
+  calendar = new Calendar(document.getElementById('calendar-container'), {
     initialView: 'dayGridMonth',
     height: 'auto',
     events,
-    eventClick: (info) => openEventModal({ ...orders.find(o=>o.id===info.event.id), id: info.event.id }),
+    editable: true,
+    eventClick: info => { location.hash = `#orders/${info.event.id}`; },
+    eventDrop: async info => {
+      await updateOrder(info.event.id, {
+        scheduledStart: Timestamp.fromDate(info.event.start),
+        scheduledEnd: info.event.end ? Timestamp.fromDate(info.event.end) : null
+      });
+    },
+    eventResize: async info => {
+      await updateOrder(info.event.id, {
+        scheduledStart: Timestamp.fromDate(info.event.start),
+        scheduledEnd: info.event.end ? Timestamp.fromDate(info.event.end) : null
+      });
+    }
   });
   calendar.render();
-
-  document.getElementById('btnNewEvent').onclick = () => openEventModal(null);
+  document.getElementById('btnNewEvent').onclick = () => openNewModal();
 };
 
-async function openEventModal(order) {
-  const clients  = await getCustomers();
+async function openNewModal() {
+  const clients = await getCustomers();
   const servicos = await getServicos();
-  const isEditing = !!order;
-  const startISO = toLocalValue(order?.start);
-  const endISO   = toLocalValue(order?.end);
-
   modalPlaceholder.innerHTML = `
-    <div class="card" style="position:fixed;inset:0;max-width:560px;margin:24px auto;background:#fff;z-index:50;overflow:auto">
-      <div class="card-header">${isEditing ? 'Editar' : 'Novo'} agendamento</div>
+    <div class="modal"><div class="card">
+      <div class="card-header">Novo agendamento</div>
       <div class="card-body">
-        <form id="form-event" class="grid">
-          <label>Título <input id="eTitle" value="${attr(order?.title||'')}" required /></label>
-          <label>Cliente
-            <select id="eCustomer">
-              <option value="">— selecione —</option>
-              ${clients.map(c=>`<option value="${c.id}" ${order?.customerId===c.id?'selected':''}>${esc(c.name||'-')}</option>`).join('')}
+        <form id="agenda-form" class="grid">
+          <label>Cliente*
+            <select id="aCustomer" required>
+              <option value="">—</option>
+              ${clients.map(c=>`<option value="${c.id}">${esc(c.name||'-')}</option>`).join('')}
             </select>
           </label>
-          <label>Serviço
-            <select id="eServico">
-              <option value="">— selecione —</option>
-              ${servicos.map(s=>`<option value="${s.id}" ${order?.servicoId===s.id?'selected':''}>${esc(s.name||'-')}</option>`).join('')}
+          <label>Veículo*
+            <select id="aVehicle" required><option value="">—</option></select>
+          </label>
+          <label>Serviço*
+            <select id="aService" required>
+              <option value="">—</option>
+              ${servicos.map(s=>`<option value="${s.id}" data-name="${attr(s.name)}" data-price="${Number(s.price)||0}">${esc(s.name)}</option>`).join('')}
             </select>
           </label>
-          <label>Início <input id="eStart" type="datetime-local" value="${startISO||''}" required /></label>
-          <label>Fim <input id="eEnd" type="datetime-local" value="${endISO||''}" /></label>
+          <label>Início* <input id="aStart" type="datetime-local" required /></label>
+          <label>Fim <input id="aEnd" type="datetime-local" /></label>
+          <label>Notas <textarea id="aNotes"></textarea></label>
           <div class="card-actions">
-            <button class="btn">${isEditing ? 'Salvar' : 'Criar'}</button>
-            ${isEditing ? '<button type="button" id="eDelete" class="link">Excluir</button>' : ''}
-            <button type="button" id="eCancel" class="link">Cancelar</button>
+            <button class="btn">Criar</button>
+            <button type="button" class="link" id="aCancel">Cancelar</button>
           </div>
         </form>
       </div>
-    </div>
+    </div></div>
   `;
-
-  document.getElementById('eCancel').onclick = closeModal;
-  if (isEditing) {
-    document.getElementById('eDelete').onclick = async () => {
-      if (confirm('Excluir agendamento?')) {
-        await deleteServiceOrder(order.id).catch(()=>{});
-        closeModal(); renderAgendaView();
-      }
-    };
-  }
-
-  document.getElementById('form-event').onsubmit = async (e) => {
+  document.getElementById('aCustomer').onchange = async e => {
+    const vs = await getVehiclesForCustomer(e.target.value);
+    document.getElementById('aVehicle').innerHTML =
+      '<option value="">—</option>' + vs.map(v=>`<option value="${v.id}">${esc(v.model||v.plate||'-')}</option>`).join('');
+  };
+  document.getElementById('aCancel').onclick = closeModal;
+  document.getElementById('agenda-form').onsubmit = async e => {
     e.preventDefault();
+    const serviceSelect = document.getElementById('aService');
+    const opt = serviceSelect.selectedOptions[0];
+    const item = { servicoId: serviceSelect.value, name: opt.dataset.name, price: Number(opt.dataset.price) };
     const data = {
-      title: document.getElementById('eTitle').value.trim(),
-      customerId: document.getElementById('eCustomer').value || null,
-      servicoId:  document.getElementById('eServico').value || null,
-      start: fromLocalValue(document.getElementById('eStart').value),
-      end:   fromLocalValue(document.getElementById('eEnd').value) || null,
+      customerId: document.getElementById('aCustomer').value,
+      vehicleId: document.getElementById('aVehicle').value,
+      items: [item],
+      discount: 0,
+      total: item.price,
+      status: 'novo',
+      notes: document.getElementById('aNotes').value.trim(),
+      scheduledStart: Timestamp.fromDate(new Date(document.getElementById('aStart').value)),
+      scheduledEnd: document.getElementById('aEnd').value ? Timestamp.fromDate(new Date(document.getElementById('aEnd').value)) : null
     };
-    if (isEditing) await updateServiceOrder(order.id, data);
-    else await addServiceOrder(data);
-    closeModal(); renderAgendaView();
+    const id = await addOrder(data);
+    closeModal();
+    renderAgendaView();
+    location.hash = `#orders/${id}`;
   };
 }
 
-function toLocalValue(v){ if(!v) return ''; const d=v.seconds?new Date(v.seconds*1000):new Date(v); const p=n=>String(n).padStart(2,'0'); return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`; }
-function fromLocalValue(s){ if(!s) return null; return Timestamp.fromDate(new Date(s)); }
 function closeModal(){ modalPlaceholder.innerHTML=''; }
+
 const esc  = (s='') => s.replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
 const attr = (s='') => esc(s).replace(/"/g,'&quot;');
+

--- a/public/js/views/ordersView.js
+++ b/public/js/views/ordersView.js
@@ -1,0 +1,236 @@
+// js/views/ordersView.js
+import {
+  getOrders, getOrderById, addOrder, updateOrder, deleteOrder,
+  getCustomers, getCustomerById,
+  getVehiclesForCustomer, getServicos
+} from '../services/firestoreService.js';
+import { Timestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const appContainer = document.getElementById('app-container');
+
+export const renderOrdersView = async (param) => {
+  if (param && param !== 'new') {
+    return renderOrderDetail(param);
+  }
+  if (param === 'new') {
+    return renderOrderDetail(null);
+  }
+  return renderOrdersList();
+};
+
+async function renderOrdersList() {
+  const orders = await getOrders();
+  const customerCache = {};
+  for (const o of orders) {
+    if (!customerCache[o.customerId]) {
+      customerCache[o.customerId] = (await getCustomerById(o.customerId))?.name || '-';
+    }
+    o.customerName = customerCache[o.customerId];
+  }
+  appContainer.innerHTML = `
+    <section class="card">
+      <h2>Ordens de Serviço</h2>
+      <div class="grid mt">
+        <select id="filter-status">
+          <option value="">Todos</option>
+          <option value="novo">Novo</option>
+          <option value="em_andamento">Em andamento</option>
+          <option value="concluido">Concluído</option>
+          <option value="cancelado">Cancelado</option>
+        </select>
+        <input type="date" id="filter-from" />
+        <input type="date" id="filter-to" />
+        <button class="btn" id="applyFilters">Filtrar</button>
+        <button class="btn" id="btnNewOrder">Nova OS</button>
+      </div>
+      <table class="mt simple-table">
+        <thead><tr><th>Cliente</th><th>Status</th><th>Total</th><th>Agendado</th><th>Criado</th><th></th></tr></thead>
+        <tbody id="orders-body"></tbody>
+      </table>
+    </section>
+  `;
+  document.getElementById('btnNewOrder').onclick = () => location.hash = '#orders/new';
+  document.getElementById('applyFilters').onclick = () => applyFilters();
+  renderOrdersTable(orders);
+
+  async function applyFilters() {
+    const status = document.getElementById('filter-status').value || null;
+    const fromVal = document.getElementById('filter-from').value;
+    const toVal   = document.getElementById('filter-to').value;
+    const from = fromVal ? Timestamp.fromDate(new Date(fromVal)) : null;
+    const to   = toVal   ? Timestamp.fromDate(new Date(toVal))   : null;
+    const list = await getOrders({ status, from, to });
+    for (const o of list) {
+      if (!customerCache[o.customerId]) {
+        customerCache[o.customerId] = (await getCustomerById(o.customerId))?.name || '-';
+      }
+      o.customerName = customerCache[o.customerId];
+    }
+    renderOrdersTable(list);
+  }
+}
+
+function renderOrdersTable(list) {
+  const body = document.getElementById('orders-body');
+  body.innerHTML = list.map(o => `
+    <tr>
+      <td>${esc(o.customerName || o.customerId)}</td>
+      <td><span class="badge ${o.status}">${o.status}</span></td>
+      <td>R$ ${(Number(o.total)||0).toFixed(2)}</td>
+      <td>${formatDate(o.scheduledStart)}</td>
+      <td>${formatDate(o.createdAt)}</td>
+      <td>
+        <button class="link" data-open="${o.id}">Abrir</button>
+        <button class="link" data-del="${o.id}">Excluir</button>
+      </td>
+    </tr>
+  `).join('') || '<tr><td colspan="6" class="muted">Nenhuma OS</td></tr>';
+  body.onclick = async e => {
+    const open = e.target.closest('[data-open]');
+    const del = e.target.closest('[data-del]');
+    if (open) {
+      location.hash = `#orders/${open.dataset.open}`;
+    } else if (del) {
+      if (confirm('Excluir OS?')) {
+        await deleteOrder(del.dataset.del);
+        renderOrdersList();
+      }
+    }
+  };
+}
+
+async function renderOrderDetail(orderId) {
+  const isNew = !orderId;
+  const order = orderId ? await getOrderById(orderId) : null;
+  const clients = await getCustomers();
+  const servicos = await getServicos();
+  let vehicles = [];
+  if (order?.customerId) {
+    vehicles = await getVehiclesForCustomer(order.customerId);
+  }
+
+  const itemsSet = new Set(order?.items?.map(i => i.servicoId));
+  appContainer.innerHTML = `
+    <section class="card print-card">
+      <h2>${isNew ? 'Nova' : 'Editar'} Ordem de Serviço</h2>
+      <form id="order-form" class="grid" aria-busy="false">
+        <label>Cliente*
+          <select id="oCustomer" required>
+            <option value="">—</option>
+            ${clients.map(c=>`<option value="${c.id}" ${order?.customerId===c.id?'selected':''}>${esc(c.name||'-')}</option>`).join('')}
+          </select>
+        </label>
+        <label>Veículo*
+          <select id="oVehicle" required>
+            <option value="">—</option>
+            ${vehicles.map(v=>`<option value="${v.id}" ${order?.vehicleId===v.id?'selected':''}>${esc(v.model||v.plate||'-')}</option>`).join('')}
+          </select>
+        </label>
+        <fieldset class="grid" id="oServices">
+          <legend>Serviços*</legend>
+          ${servicos.map(s=>`
+            <label class="checkbox"><input type="checkbox" value="${s.id}" data-name="${attr(s.name)}" data-price="${Number(s.price)||0}" ${itemsSet.has(s.id)?'checked':''}/> ${esc(s.name)} (R$ ${(Number(s.price)||0).toFixed(2)})</label>
+          `).join('')}
+        </fieldset>
+        <label>Desconto <input id="oDiscount" type="number" min="0" step="0.01" value="${order?.discount||0}" /></label>
+        <div>Total: <span id="oTotal">R$ ${(Number(order?.total)||0).toFixed(2)}</span></div>
+        <label>Status
+          <select id="oStatus">
+            ${['novo','em_andamento','concluido','cancelado'].map(st=>`<option value="${st}" ${order?.status===st?'selected':''}>${st}</option>`).join('')}
+          </select>
+        </label>
+        <label>Notas <textarea id="oNotes">${esc(order?.notes||'')}</textarea></label>
+        <label>Início <input id="oStart" type="datetime-local" value="${toLocal(order?.scheduledStart)||''}" /></label>
+        <label>Fim <input id="oEnd" type="datetime-local" value="${toLocal(order?.scheduledEnd)||''}" /></label>
+        <div class="card-actions">
+          <button class="btn">${isNew?'Criar':'Salvar'}</button>
+          ${!isNew?'<button type="button" id="oDelete" class="link">Excluir</button>':''}
+          <button type="button" id="oBack" class="link">Voltar</button>
+          ${!isNew?'<button type="button" id="oPrint" class="link no-print">Imprimir</button>':''}
+          ${!isNew?'<button type="button" id="oCSV" class="link">CSV</button>':''}
+        </div>
+      </form>
+    </section>
+  `;
+
+  document.getElementById('oCustomer').onchange = async e => {
+    const cid = e.target.value;
+    const vs = cid ? await getVehiclesForCustomer(cid) : [];
+    document.getElementById('oVehicle').innerHTML =
+      '<option value="">—</option>' + vs.map(v=>`<option value="${v.id}">${esc(v.model||v.plate||'-')}</option>`).join('');
+  };
+
+  document.getElementById('oServices').addEventListener('change', calcTotal);
+  document.getElementById('oDiscount').addEventListener('input', calcTotal);
+  calcTotal();
+
+  document.getElementById('oBack').onclick = () => { location.hash = '#orders'; };
+  if (!isNew) {
+    document.getElementById('oDelete').onclick = async () => {
+      if (confirm('Excluir OS?')) { await deleteOrder(orderId); location.hash = '#orders'; }
+    };
+    document.getElementById('oPrint').onclick = () => window.print();
+    document.getElementById('oCSV').onclick = () => exportCSV(orderId, order);
+  }
+
+  document.getElementById('order-form').onsubmit = async ev => {
+    ev.preventDefault();
+    const form = ev.currentTarget;
+    form.setAttribute('aria-busy','true');
+    const customerId = document.getElementById('oCustomer').value;
+    const vehicleId = document.getElementById('oVehicle').value;
+    const discount = Number(document.getElementById('oDiscount').value)||0;
+    const status = document.getElementById('oStatus').value;
+    const notes = document.getElementById('oNotes').value.trim();
+    const startVal = document.getElementById('oStart').value;
+    const endVal   = document.getElementById('oEnd').value;
+    const items = Array.from(document.querySelectorAll('#oServices input:checked')).map(inp => ({
+      servicoId: inp.value,
+      name: inp.dataset.name,
+      price: Number(inp.dataset.price)
+    }));
+    const subtotal = items.reduce((s,i)=>s+i.price,0);
+    const total = Math.max(0, subtotal - discount);
+    if(!customerId || !vehicleId || items.length===0){ form.removeAttribute('aria-busy'); return; }
+    const data = {
+      customerId,
+      vehicleId,
+      items,
+      discount,
+      total,
+      status,
+      notes,
+      scheduledStart: startVal ? Timestamp.fromDate(new Date(startVal)) : null,
+      scheduledEnd: endVal ? Timestamp.fromDate(new Date(endVal)) : null
+    };
+    let newId = orderId;
+    if (isNew) newId = await addOrder(data); else await updateOrder(orderId, data);
+    form.removeAttribute('aria-busy');
+    location.hash = `#orders/${newId}`;
+  };
+}
+
+function calcTotal() {
+  const items = Array.from(document.querySelectorAll('#oServices input:checked')).map(i => Number(i.dataset.price));
+  const discount = Number(document.getElementById('oDiscount').value)||0;
+  const subtotal = items.reduce((s,v)=>s+v,0);
+  const total = Math.max(0, subtotal - discount);
+  document.getElementById('oTotal').textContent = 'R$ ' + total.toFixed(2);
+}
+
+function exportCSV(id, order) {
+  const lines = order.items.map(i=>`${i.name},${(Number(i.price)||0).toFixed(2)}`);
+  lines.push(`Desconto,${(Number(order.discount)||0).toFixed(2)}`);
+  lines.push(`Total,${(Number(order.total)||0).toFixed(2)}`);
+  const blob = new Blob([lines.join('\n')], { type:'text/csv' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `os-${id}.csv`;
+  a.click();
+}
+
+function toLocal(ts){ if(!ts) return ''; const d=ts.seconds? new Date(ts.seconds*1000):new Date(ts); const p=n=>String(n).padStart(2,'0'); return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`; }
+function formatDate(ts){ if(!ts) return ''; const d=ts.seconds? new Date(ts.seconds*1000):new Date(ts); return d.toLocaleDateString(); }
+const esc  = (s='') => s.replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+const attr = (s='') => esc(s).replace(/"/g,'&quot;');
+

--- a/public/js/views/servicosView.js
+++ b/public/js/views/servicosView.js
@@ -3,87 +3,117 @@ import { getServicos, addServico, getServicoById, updateServico, deleteServico }
 
 const appContainer = document.getElementById('app-container');
 const modalPlaceholder = document.getElementById('modal-placeholder');
+let servicos = [];
 
 export const renderServicosView = async () => {
-  const servicos = await getServicos();
+  servicos = await getServicos();
   appContainer.innerHTML = `
     <section class="card">
       <h2>Serviços</h2>
-      <form id="form-servico" class="grid mt">
-        <label>Nome <input id="sName" required /></label>
-        <label>Preço (R$) <input id="sPrice" type="number" min="0" step="0.01" required /></label>
+      <div id="s-alert" class="alert" aria-live="polite"></div>
+      <form id="form-servico" class="grid mt" aria-busy="false">
+        <label>Nome* <input id="sName" required /></label>
+        <label>Preço* <input id="sPrice" type="number" min="0" step="0.01" required /></label>
         <button class="btn">Adicionar</button>
       </form>
-
-      <div class="grid-2 mt">
-        ${servicos.map(s => `
-          <div class="card">
-            <div class="card-header">${esc(s.name || '-')}</div>
-            <div class="card-body">
-              <p><b>Preço:</b> R$ ${(Number(s.price)||0).toFixed(2)}</p>
-            </div>
-            <div class="card-actions">
-              <button class="btn" data-edit="${s.id}">Editar</button>
-              <button class="link" data-del="${s.id}">Excluir</button>
-            </div>
-          </div>
-        `).join('')}
-      </div>
+      <input id="sSearch" class="input mt" type="search" placeholder="Buscar por nome" />
+      <div id="servicos-list" class="mt"></div>
     </section>
   `;
-
-  document.getElementById('form-servico').onsubmit = async (e) => {
-    e.preventDefault();
-    const name = document.getElementById('sName').value.trim();
-    const price = Number(document.getElementById('sPrice').value);
-    if (!name) return;
-    await addServico(name, price);
-    renderServicosView();
-  };
-
-  appContainer.onclick = async (e) => {
-    const btnEdit = e.target.closest('button[data-edit]');
-    const btnDel  = e.target.closest('button[data-del]');
-    if (btnDel) {
-      if (confirm('Excluir serviço?')) {
-        await deleteServico(btnDel.dataset.del).catch(()=>{});
-        renderServicosView();
-      }
-    } else if (btnEdit) {
-      const id = btnEdit.dataset.edit;
-      const s = await getServicoById(id);
-      openEditModal(s);
-    }
-  };
+  document.getElementById('form-servico').onsubmit = onAddServico;
+  document.getElementById('sSearch').addEventListener('input', renderList);
+  renderList();
 };
 
-function openEditModal(servico) {
+async function onAddServico(e) {
+  e.preventDefault();
+  const form = e.currentTarget;
+  form.setAttribute('aria-busy','true');
+  const name = document.getElementById('sName').value.trim();
+  const price = Number(document.getElementById('sPrice').value);
+  const alertBox = document.getElementById('s-alert');
+
+  if (!name) { alertBox.textContent='Nome obrigatório'; form.removeAttribute('aria-busy'); return; }
+  if (isNaN(price) || price < 0) { alertBox.textContent='Preço inválido'; form.removeAttribute('aria-busy'); return; }
+  if (servicos.some(s => (s.name||'').toLowerCase() === name.toLowerCase())) {
+    alertBox.textContent='Nome já existe';
+    form.removeAttribute('aria-busy');
+    return;
+  }
+  await addServico({ name, price });
+  document.getElementById('sName').value='';
+  document.getElementById('sPrice').value='';
+  alertBox.textContent='Serviço adicionado';
+  servicos = await getServicos();
+  renderList();
+  form.removeAttribute('aria-busy');
+}
+
+function renderList() {
+  const term = document.getElementById('sSearch').value.toLowerCase();
+  const listEl = document.getElementById('servicos-list');
+  const filtered = term ? servicos.filter(s => (s.name||'').toLowerCase().includes(term)) : servicos;
+  listEl.innerHTML = filtered.map(s => `
+    <div class="simple-list-item">
+      <div>
+        <strong>${esc(s.name||'-')}</strong><br/>
+        <small class="muted">R$ ${(Number(s.price)||0).toFixed(2)} • ${formatDate(s.createdAt)}</small>
+      </div>
+      <div>
+        <button class="btn btn-sm" data-edit="${s.id}">Editar</button>
+        <button class="link" data-del="${s.id}">Excluir</button>
+      </div>
+    </div>
+  `).join('') || '<p class="muted">Nenhum serviço.</p>';
+  listEl.onclick = onListClick;
+}
+
+function onListClick(e) {
+  const del = e.target.closest('[data-del]');
+  const edit = e.target.closest('[data-edit]');
+  if (del) {
+    if (confirm('Excluir serviço?')) {
+      deleteServico(del.dataset.del).then(async () => {
+        servicos = await getServicos();
+        renderList();
+      });
+    }
+  } else if (edit) {
+    openEditModal(edit.dataset.edit);
+  }
+}
+
+async function openEditModal(id) {
+  const s = await getServicoById(id);
   modalPlaceholder.innerHTML = `
-    <div class="card" style="position:fixed;inset:0;max-width:480px;margin:40px auto;background:#fff;z-index:50">
+    <div class="modal"><div class="card">
       <div class="card-header">Editar serviço</div>
       <div class="card-body">
-        <form id="form-edit-servico" class="grid">
-          <label>Nome <input id="esName" value="${attr(servico.name||'')}" required /></label>
-          <label>Preço (R$) <input id="esPrice" type="number" min="0" step="0.01" value="${Number(servico.price)||0}" required /></label>
+        <form id="edit-servico" class="grid">
+          <label>Nome* <input id="esName" value="${attr(s.name||'')}" required /></label>
+          <label>Preço* <input id="esPrice" type="number" min="0" step="0.01" value="${Number(s.price)||0}" required /></label>
           <div class="card-actions">
             <button class="btn">Salvar</button>
             <button type="button" class="link" id="closeModal">Cancelar</button>
           </div>
         </form>
       </div>
-    </div>
+    </div></div>
   `;
   document.getElementById('closeModal').onclick = closeModal;
-  document.getElementById('form-edit-servico').onsubmit = async (e) => {
-    e.preventDefault();
-    const name  = document.getElementById('esName').value.trim();
+  document.getElementById('edit-servico').onsubmit = async ev => {
+    ev.preventDefault();
+    const name = document.getElementById('esName').value.trim();
     const price = Number(document.getElementById('esPrice').value);
-    await updateServico(servico.id, { name, price });
+    await updateServico(id, { name, price });
     closeModal();
-    renderServicosView();
+    servicos = await getServicos();
+    renderList();
   };
 }
 
 function closeModal(){ modalPlaceholder.innerHTML=''; }
+function formatDate(ts){ if(!ts) return ''; const d=ts.seconds? new Date(ts.seconds*1000):new Date(ts); return d.toLocaleDateString(); }
 const esc  = (s='') => s.replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
 const attr = (s='') => esc(s).replace(/"/g,'&quot;');
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -438,3 +438,20 @@ main#app-container {
 .muted {
     color: var(--muted);
 }
+
+/* utilitários adicionais */
+.simple-table{width:100%;border-collapse:collapse;}
+.simple-table th,.simple-table td{padding:4px;border-bottom:1px solid var(--border);text-align:left;}
+.badge{display:inline-block;padding:2px 6px;border-radius:4px;font-size:.75rem;text-transform:capitalize;}
+.badge.novo{background:#dbeafe;color:#1e40af;}
+.badge.em_andamento{background:#fef9c3;color:#854d0e;}
+.badge.concluido{background:#dcfce7;color:#166534;}
+.badge.cancelado{background:#fee2e2;color:#991b1b;}
+.modal{position:fixed;inset:0;background:rgba(0,0,0,.3);display:flex;align-items:flex-start;justify-content:center;padding:1rem;z-index:100;}
+.modal .card{margin-top:2rem;width:100%;max-width:600px;}
+.simple-list-item{display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border);padding:.5rem 0;}
+@media print{
+  header,nav,.no-print,button,input,select,textarea{display:none !important;}
+  body{background:#fff;}
+  .print-card{border:none;box-shadow:none;}
+}


### PR DESCRIPTION
## Summary
- add CRUD for services and orders with Firestore
- integrate orders with FullCalendar agenda
- update navigation and styles for tables and badges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cfe2074c4832e87dea1887d06ee56