### PR TITLE
feat: add reports, admin views and backup

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,22 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function signedIn() { return request.auth != null; }
+    function isAdmin() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+    }
+    match /users/{uid} {
+      allow read: if signedIn() && (uid == request.auth.uid || isAdmin());
+      allow write: if isAdmin();
+    }
     match /{document=**} {
       allow read, write: if signedIn();
     }
   }
 }
+
+// índices necessários:
+// orders(createdAt desc)
+// orders(status asc, createdAt desc)
+// orders(scheduledStart asc)
+// services(createdAt desc)
+// users(createdAt desc)

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,9 @@
             <a href="#orders">Ordens</a>
             <a href="#clientes">Clientes</a>
             <a href="#servicos">Serviços</a>
+            <a href="#relatorios">Relatórios</a>
+            <a href="#usuarios" class="admin-only" style="display:none;">Usuários</a>
+            <a href="#config" class="admin-only" style="display:none;">Config.</a>
             <span id="whoami" class="muted"></span>
             <button id="btnSignOut" class="link">Sair</button>
         </nav>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,5 +1,6 @@
 import { auth } from './firebase-config.js';
 import { navigate } from './router.js';
+import { ensureUserDocOnLogin } from './services/firestoreService.js';
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
@@ -175,8 +176,13 @@ resetForm?.addEventListener('submit', async (e) => {
 
 btnSignOut?.addEventListener('click', () => signOutUser());
 
-onAuthStateChanged(auth, (user) => {
+onAuthStateChanged(auth, async (user) => {
   if (user) {
+    const userDoc = await ensureUserDocOnLogin(user);
+    window.sessionState = { role: userDoc?.role || 'user' };
+    document.querySelectorAll('.admin-only').forEach(el => {
+      el.style.display = window.sessionState.role === 'admin' ? '' : 'none';
+    });
     whoami.textContent = user.email;
     nav.style.display = '';
     authShell.style.display = 'none';
@@ -185,6 +191,8 @@ onAuthStateChanged(auth, (user) => {
     }
     navigate();
   } else {
+    window.sessionState = {};
+    document.querySelectorAll('.admin-only').forEach(el => { el.style.display = 'none'; });
     whoami.textContent = '';
     nav.style.display = 'none';
     authShell.style.display = '';

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -3,6 +3,9 @@ import { renderServicosView } from './views/servicosView.js';
 import { renderAgendaView } from './views/agendaView.js';
 import { renderOrdersView } from './views/ordersView.js';
 import { renderDashboardView } from './views/dashboardView.js';
+import { renderReportsView } from './views/reportsView.js';
+import { renderSettingsView } from './views/settingsView.js';
+import { renderUsersView } from './views/usersView.js';
 import { auth } from './firebase-config.js';
 
 const appContainer = document.getElementById('app-container');
@@ -13,6 +16,9 @@ const routes = {
   '#clientes': renderClientesView,
   '#servicos': renderServicosView,
   '#orders': renderOrdersView,
+  '#relatorios': renderReportsView,
+  '#config': renderSettingsView,
+  '#usuarios': renderUsersView,
 };
 
 export function navigate() {
@@ -35,6 +41,13 @@ export function navigate() {
 
   const [mainPath, ...rest] = hash.split('/');
   const param = rest.join('/') || null;
+
+  const adminRoutes = ['#usuarios', '#config'];
+  const role = window.sessionState?.role;
+  if (adminRoutes.includes(mainPath) && role !== 'admin') {
+    location.hash = '#dashboard';
+    return;
+  }
 
   const navLinks = document.querySelectorAll('#main-nav a');
   navLinks.forEach(link => link.classList.remove('active'));

--- a/public/js/views/reportsView.js
+++ b/public/js/views/reportsView.js
@@ -1,0 +1,84 @@
+import { Timestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+import { getOrdersFinished, getOrdersByStatus, getCycleDurations } from '../services/firestoreService.js';
+
+export async function renderReportsView() {
+  const container = document.getElementById('app-container');
+  container.innerHTML = `
+    <h2>Relatórios</h2>
+    <div class="tabs">
+      <button id="tab-fin" class="btn btn-secondary">Financeiro</button>
+      <button id="tab-op" class="btn btn-secondary">Operacional</button>
+    </div>
+    <section id="report-content" aria-live="polite" class="mt"></section>
+  `;
+
+  document.getElementById('tab-fin').addEventListener('click', () => loadFinanceiro());
+  document.getElementById('tab-op').addEventListener('click', () => loadOperacional());
+  loadFinanceiro();
+}
+
+async function loadFinanceiro() {
+  const area = document.getElementById('report-content');
+  area.innerHTML = '<p class="skeleton">Carregando...</p>';
+  const to = Timestamp.now();
+  const from = Timestamp.fromDate(new Date(Date.now() - 7*86400000));
+  const orders = await getOrdersFinished({ from, to });
+  if (!orders.length) {
+    area.innerHTML = '<p>Nenhuma OS concluída.</p>';
+    return;
+  }
+  const totals = {};
+  orders.forEach(o => {
+    const day = o.closedAt?.toDate().toISOString().slice(0,10);
+    if (!totals[day]) totals[day] = { count:0, subtotal:0, discount:0, total:0 };
+    totals[day].count++;
+    totals[day].subtotal += Number(o.subtotal || 0);
+    totals[day].discount += Number(o.discount || 0);
+    totals[day].total += Number(o.total || 0);
+  });
+  let html = '<table class="table"><thead><tr><th>Dia</th><th>Qtd</th><th>Subtotal</th><th>Desc.</th><th>Total</th></tr></thead><tbody>';
+  Object.entries(totals).forEach(([day,val]) => {
+    html += `<tr><td>${day}</td><td>${val.count}</td><td>${val.subtotal.toFixed(2)}</td><td>${val.discount.toFixed(2)}</td><td>${val.total.toFixed(2)}</td></tr>`;
+  });
+  html += '</tbody></table><button id="fin-csv" class="btn btn-primary mt">Exportar CSV</button>';
+  area.innerHTML = html;
+  document.getElementById('fin-csv').addEventListener('click', () => {
+    const rows = [['dia','qtd','subtotal','desconto','total']];
+    Object.entries(totals).forEach(([d,v])=>rows.push([d,v.count,v.subtotal,v.discount,v.total]));
+    const csv = rows.map(r=>r.join(',')).join('\n');
+    const blob = new Blob([csv], {type:'text/csv;charset=utf-8;'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'financeiro.csv';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+}
+
+async function loadOperacional() {
+  const area = document.getElementById('report-content');
+  area.innerHTML = '<p class="skeleton">Carregando...</p>';
+  const to = Timestamp.now();
+  const from = Timestamp.fromDate(new Date(Date.now() - 7*86400000));
+  const status = await getOrdersByStatus({ from, to });
+  const cycle = await getCycleDurations({ from, to });
+  let html = '<div class="grid">';
+  Object.entries(status).forEach(([st,q])=>{
+    html += `<span class="badge ${st}">${st}: ${q}</span>`;
+  });
+  html += `</div><p class="mt">Tempo médio: ${(cycle.avg/3600000).toFixed(2)}h</p>`;
+  html += '<button id="op-csv" class="btn btn-primary mt">Exportar CSV</button>';
+  area.innerHTML = html;
+  document.getElementById('op-csv').addEventListener('click', () => {
+    const rows = [['status','quantidade']];
+    Object.entries(status).forEach(([st,q])=>rows.push([st,q]));
+    rows.push(['tempo_medio_horas',(cycle.avg/3600000).toFixed(2)]);
+    const csv = rows.map(r=>r.join(',')).join('\n');
+    const blob = new Blob([csv], {type:'text/csv;charset=utf-8;'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'operacional.csv';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+}

--- a/public/js/views/settingsView.js
+++ b/public/js/views/settingsView.js
@@ -1,0 +1,32 @@
+import { exportCollections, importCollections } from '../services/firestoreService.js';
+
+export function renderSettingsView() {
+  const container = document.getElementById('app-container');
+  container.innerHTML = `
+    <h2>Configurações</h2>
+    <section class="mt">
+      <h3>Backup</h3>
+      <button id="btn-backup" class="btn btn-primary">Exportar JSON</button>
+      <input type="file" id="backup-file" accept="application/json" class="mt" />
+      <button id="btn-restore" class="btn btn-secondary mt">Importar JSON</button>
+    </section>
+  `;
+
+  document.getElementById('btn-backup').addEventListener('click', async () => {
+    const json = await exportCollections(['customers','vehicles','services','orders']);
+    const blob = new Blob([json], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'backup.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  document.getElementById('btn-restore').addEventListener('click', async () => {
+    const file = document.getElementById('backup-file').files[0];
+    if (!file) return;
+    const text = await file.text();
+    await importCollections(text, { mode: 'merge', collections: ['customers','vehicles','services','orders'] });
+    alert('Importação concluída');
+  });
+}

--- a/public/js/views/usersView.js
+++ b/public/js/views/usersView.js
@@ -1,0 +1,39 @@
+import { getUsers, updateUserRole, toggleUserActive } from '../services/firestoreService.js';
+
+export async function renderUsersView() {
+  const container = document.getElementById('app-container');
+  container.innerHTML = '<h2>Usuários</h2><p class="skeleton">Carregando...</p>';
+  const users = await getUsers();
+  const table = document.createElement('table');
+  table.className = 'table';
+  table.innerHTML = `<thead><tr><th>Email</th><th>Nome</th><th>Papel</th><th>Ativo</th></tr></thead><tbody></tbody>`;
+  const tbody = table.querySelector('tbody');
+  users.forEach(u => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${u.email || ''}</td>
+      <td>${u.displayName || ''}</td>
+      <td>
+        <select data-role="${u.id}">
+          <option value="user" ${u.role === 'user' ? 'selected' : ''}>user</option>
+          <option value="admin" ${u.role === 'admin' ? 'selected' : ''}>admin</option>
+        </select>
+      </td>
+      <td><input type="checkbox" data-active="${u.id}" ${u.active ? 'checked' : ''}></td>
+    `;
+    tbody.appendChild(tr);
+  });
+  container.innerHTML = '<h2>Usuários</h2>';
+  container.appendChild(table);
+
+  container.addEventListener('change', (e) => {
+    if (e.target.matches('select[data-role]')) {
+      const uid = e.target.dataset.role;
+      updateUserRole(uid, e.target.value);
+    }
+    if (e.target.matches('input[data-active]')) {
+      const uid = e.target.dataset.active;
+      toggleUserActive(uid, e.target.checked);
+    }
+  });
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -447,6 +447,8 @@ main#app-container {
 .badge.em_andamento{background:#fef9c3;color:#854d0e;}
 .badge.concluido{background:#dcfce7;color:#166534;}
 .badge.cancelado{background:#fee2e2;color:#991b1b;}
+.table{width:100%;border-collapse:collapse;margin-top:1rem;}
+.table th,.table td{border:1px solid var(--border);padding:.5rem;text-align:left;}
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.3);display:flex;align-items:flex-start;justify-content:center;padding:1rem;z-index:100;}
 .modal .card{margin-top:2rem;width:100%;max-width:600px;}
 .simple-list-item{display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--border);padding:.5rem 0;}

--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,13 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
+    function signedIn() { return request.auth != null; }
+    function isAdmin() {
+      return get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'admin';
+    }
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read, write: if signedIn();
+      allow delete: if signedIn() && (isAdmin() || request.auth.uid == resource.metadata.uploadedBy);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add reporting utilities and backup helpers to Firestore service
- introduce reports, settings and users views with navigation
- secure admin routes and expand Firebase rules

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d067a65f8832e8604f801d0ce5fc3