### PR TITLE
feat: agenda notifications offline

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,14 @@ service cloud.firestore {
       allow read: if signedIn() && (uid == request.auth.uid || isAdmin());
       allow write: if isAdmin();
     }
+    match /auditLogs/{id} {
+      allow read: if signedIn();
+      allow write: if false;
+    }
+    match /orders/{id} {
+      allow read: if signedIn();
+      allow write: if isAdmin();
+    }
     match /{document=**} {
       allow read, write: if signedIn();
     }
@@ -16,8 +24,9 @@ service cloud.firestore {
 }
 
 // índices necessários:
-// orders(createdAt desc)
-// orders(status asc, createdAt desc)
 // orders(scheduledStart asc)
+// orders(status asc, createdAt desc)
+// orders(customerId asc, scheduledStart asc)
+// orders(vehicleId asc, scheduledStart asc)
+// users(role asc)
 // services(createdAt desc)
-// users(createdAt desc)

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,100 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+const db = admin.firestore();
+
+async function getAdminTokens() {
+  const snap = await db.collection('users').where('role','==','admin').get();
+  const tokens = [];
+  snap.forEach(doc=>{ (doc.data().fcmTokens||[]).forEach(t=>tokens.push(t)); });
+  return tokens;
+}
+
+exports.scheduledNotifier = functions.pubsub.schedule('every 30 minutes').onRun(async () => {
+  const now = admin.firestore.Timestamp.now();
+  const end = admin.firestore.Timestamp.fromDate(new Date(Date.now() + 24*60*60*1000));
+  const snap = await db.collection('orders')
+    .where('scheduledStart','>=',now)
+    .where('scheduledStart','<=',end)
+    .where('notified24h','!=', true)
+    .get();
+  const adminTokens = await getAdminTokens();
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const tokens = [...adminTokens];
+    if (data.assignedTo) {
+      const u = await db.collection('users').doc(data.assignedTo).get();
+      (u.data().fcmTokens||[]).forEach(t=>tokens.push(t));
+    }
+    if (tokens.length) {
+      await admin.messaging().sendEachForMulticast({
+        tokens,
+        notification: { title: 'Lembrete de OS', body: data.items?.[0]?.name || '' }
+      });
+    }
+    await doc.ref.update({ notified24h: true });
+    try {
+      await db.collection('mail').add({
+        to: [data.email || ''],
+        message: { subject: 'Lembrete de serviço', text: 'Seu serviço ocorrerá em breve.' }
+      });
+    } catch(e) {}
+  }
+});
+
+exports.orderStatusNotify = functions.firestore.document('orders/{id}').onWrite(async (change, context) => {
+  const before = change.before.data();
+  const after = change.after.data();
+  if (!after) return;
+  if (before && before.status === after.status) return;
+  if (!['em_andamento','concluido'].includes(after.status)) return;
+  const tokens = await getAdminTokens();
+  if (after.assignedTo) {
+    const u = await db.collection('users').doc(after.assignedTo).get();
+    (u.data().fcmTokens||[]).forEach(t=>tokens.push(t));
+  }
+  if (tokens.length) {
+    await admin.messaging().sendEachForMulticast({
+      tokens,
+      notification: { title: `OS ${after.status}`, body: after.notes || '' }
+    });
+  }
+});
+
+function diff(before, after) {
+  const out = {};
+  Object.keys(after || {}).forEach(k => {
+    if (JSON.stringify(before?.[k]) !== JSON.stringify(after[k])) {
+      out[k] = { before: before?.[k], after: after[k] };
+    }
+  });
+  Object.keys(before || {}).forEach(k => {
+    if (!(k in (after||{}))) {
+      out[k] = { before: before[k], after: null };
+    }
+  });
+  return out;
+}
+
+function logChange(collection) {
+  return functions.firestore.document(`${collection}/{id}`).onWrite(async (change, context) => {
+    const before = change.before.exists ? change.before.data() : null;
+    const after = change.after.exists ? change.after.data() : null;
+    const action = !before ? 'create' : !after ? 'delete' : 'update';
+    const d = diff(before, after);
+    await db.collection('auditLogs').add({
+      collection,
+      docId: context.params.id,
+      action,
+      diff: d,
+      ts: admin.firestore.FieldValue.serverTimestamp(),
+      actorUid: context.auth?.uid || null,
+      actorEmail: context.auth?.token?.email || null
+    });
+  });
+}
+
+exports.customerLog = logChange('customers');
+exports.vehicleLog = logChange('vehicles');
+exports.serviceLog = logChange('services');
+exports.orderLog = logChange('orders');

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "functions",
+  "engines": { "node": "18" },
+  "dependencies": {
+    "firebase-admin": "^11.11.0",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,20 @@
+importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: "AIzaSyAaaXxKG4BwAKIBdDk0vrSNsQzK8BbWIA0",
+  authDomain: "brancofilmcv.firebaseapp.com",
+  projectId: "brancofilmcv",
+  storageBucket: "brancofilmcv.firebasestorage.app",
+  messagingSenderId: "513537369615",
+  appId: "1:513537369615:web:6cfec35394b5852857e57a"
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(payload => {
+  const notification = payload.notification || {};
+  self.registration.showNotification(notification.title || '', {
+    body: notification.body || ''
+  });
+});

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,10 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.min.css">
+    <script>
+      const theme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.dataset.theme = theme;
+    </script>
 </head>
 <body>
     <header>
@@ -23,6 +27,8 @@
             <a href="#usuarios" class="admin-only" style="display:none;">Usuários</a>
             <a href="#config" class="admin-only" style="display:none;">Config.</a>
             <span id="whoami" class="muted"></span>
+            <span id="net-status" class="offline-indicator" hidden>OFFLINE</span>
+            <button id="themeToggle" class="link" type="button">Tema</button>
             <button id="btnSignOut" class="link">Sair</button>
         </nav>
     </header>
@@ -104,8 +110,19 @@
 
     <script type="module" src="js/auth.js"></script>
     <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/messaging.js"></script>
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
-    <script>if('serviceWorker' in navigator){navigator.serviceWorker.register('/service-worker.js');}</script>
+    <script>
+      if('serviceWorker' in navigator){
+        navigator.serviceWorker.register('/service-worker.js');
+        navigator.serviceWorker.register('/firebase-messaging-sw.js');
+      }
+      document.getElementById('themeToggle').addEventListener('click', () => {
+        const t = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+        document.documentElement.dataset.theme = t;
+        localStorage.setItem('theme', t);
+      });
+    </script>
 </body>
 </html>
 

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,6 +1,7 @@
 import { auth } from './firebase-config.js';
 import { navigate } from './router.js';
-import { ensureUserDocOnLogin } from './services/firestoreService.js';
+import { ensureUserDocOnLogin, enableOfflinePersistence } from './services/firestoreService.js';
+import { requestPermissionAndToken } from './messaging.js';
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
@@ -8,6 +9,8 @@ import {
   signOut as firebaseSignOut,
   onAuthStateChanged
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+
+enableOfflinePersistence().catch(()=>{});
 
 export function signIn(email, pass) {
   return signInWithEmailAndPassword(auth, email, pass);
@@ -189,6 +192,7 @@ onAuthStateChanged(auth, async (user) => {
     if (location.hash === '#login' || !location.hash) {
       location.hash = '#dashboard';
     }
+    await requestPermissionAndToken();
     navigate();
   } else {
     window.sessionState = {};

--- a/public/js/messaging.js
+++ b/public/js/messaging.js
@@ -1,0 +1,30 @@
+import { getMessaging, getToken, onMessage } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging.js";
+import { app, auth } from './firebase-config.js';
+import { saveUserFcmToken } from './services/firestoreService.js';
+
+const messaging = getMessaging(app);
+const VAPID_KEY = 'REPLACE_WITH_VAPID_KEY';
+
+export async function requestPermissionAndToken() {
+  if (!('Notification' in window)) return;
+  if (Notification.permission === 'default') {
+    await Notification.requestPermission();
+  }
+  if (Notification.permission !== 'granted') return;
+  const reg = await navigator.serviceWorker.getRegistration('/firebase-messaging-sw.js');
+  try {
+    const token = await getToken(messaging, { vapidKey: VAPID_KEY, serviceWorkerRegistration: reg });
+    if (auth.currentUser && token) await saveUserFcmToken(auth.currentUser.uid, token);
+  } catch (err) {
+    console.warn('FCM token error', err);
+  }
+}
+
+onMessage(messaging, payload => {
+  const msg = payload.notification?.title || 'Notificação';
+  const el = document.createElement('div');
+  el.className = 'toast';
+  el.textContent = msg;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 4000);
+});

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -9,6 +9,20 @@ import { renderUsersView } from './views/usersView.js';
 import { auth } from './firebase-config.js';
 
 const appContainer = document.getElementById('app-container');
+const netStatus = document.getElementById('net-status');
+
+function updateNetStatus() {
+  if (!netStatus) return;
+  netStatus.hidden = navigator.onLine;
+}
+
+window.addEventListener('online', updateNetStatus);
+window.addEventListener('offline', updateNetStatus);
+updateNetStatus();
+
+window.addEventListener('orders:changed', () => {
+  if (location.hash.startsWith('#agenda')) renderAgendaView();
+});
 
 const routes = {
   '#dashboard': renderDashboardView,

--- a/public/styles.css
+++ b/public/styles.css
@@ -10,6 +10,13 @@
     --ring: #2563eb;
 }
 
+[data-theme="dark"] {
+    --bg: #0f172a;
+    --card: #1e293b;
+    --primary: #f8fafc;
+    --border: #334155;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -57,6 +64,44 @@ nav a {
 nav a:hover, nav a.active {
     background-color: #e7f3ff;
     color: #0056b3;
+}
+
+.badge.novo { background:#eef2ff; color:#3730a3; }
+.badge.em_andamento { background:#fff7ed; color:#c2410c; }
+.badge.concluido { background:#ecfdf5; color:#047857; }
+.badge.cancelado { background:#fee2e2; color:#b91c1c; }
+
+.toast {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background: var(--card);
+    border: 1px solid var(--border);
+    padding: .5rem 1rem;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,.2);
+    z-index: 1000;
+}
+
+.offline-indicator {
+    background: #b91c1c;
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: .75rem;
+    margin-left: .5rem;
+}
+
+.skeleton {
+    background: #e2e8f0;
+    height: 1rem;
+    animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+    0% { opacity: 1; }
+    50% { opacity: .4; }
+    100% { opacity: 1; }
 }
 
 /* --- CONTAINER PRINCIPAL --- */

--- a/storage.rules
+++ b/storage.rules
@@ -6,7 +6,8 @@ service firebase.storage {
       return get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'admin';
     }
     match /{allPaths=**} {
-      allow read, write: if signedIn();
+      allow read: if signedIn();
+      allow create, update: if signedIn();
       allow delete: if signedIn() && (isAdmin() || request.auth.uid == resource.metadata.uploadedBy);
     }
   }


### PR DESCRIPTION
## Summary
- color and filter calendar events with drag/resize conflict detection
- save FCM tokens, offline persistence and theme toggle
- add order assignee, email action and audit history

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d0a77d0d4832e89d99885e0cc21b4