### PR TITLE
Fix duplicate getOrdersByStatus helper

### DIFF
--- a/public/js/services/firestoreService.js
+++ b/public/js/services/firestoreService.js
@@ -211,7 +211,7 @@ export async function getOrdersFinished({ from, to } = {}) {
   return snap.docs.map(d => ({ id: d.id, ...d.data() }));
 }
 
-export async function getOrdersByStatus({ from, to } = {}) {
+export async function countOrdersByStatus({ from, to } = {}) {
   let q = ordersCollection;
   if (from) q = query(q, where('createdAt', '>=', from));
   if (to)   q = query(q, where('createdAt', '<=', to));

--- a/public/js/views/reportsView.js
+++ b/public/js/views/reportsView.js
@@ -1,5 +1,5 @@
 import { Timestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-import { getOrdersFinished, getOrdersByStatus, getCycleDurations } from '../services/firestoreService.js';
+import { getOrdersFinished, countOrdersByStatus, getCycleDurations } from '../services/firestoreService.js';
 
 export async function renderReportsView() {
   const container = document.getElementById('app-container');
@@ -60,7 +60,7 @@ async function loadOperacional() {
   area.innerHTML = '<p class="skeleton">Carregando...</p>';
   const to = Timestamp.now();
   const from = Timestamp.fromDate(new Date(Date.now() - 7*86400000));
-  const status = await getOrdersByStatus({ from, to });
+  const status = await countOrdersByStatus({ from, to });
   const cycle = await getCycleDurations({ from, to });
   let html = '<div class="grid">';
   Object.entries(status).forEach(([st,q])=>{


### PR DESCRIPTION
## Summary
- Rename report helper to `countOrdersByStatus` to avoid duplicate export
- Update reports view to use the new helper

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/brancofilm/package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/brancofilm/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689d10635490832e84bcdd3e78c13d58