### PR TITLE
feat: scaffold advanced reports and basic i18n

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,8 +5,25 @@ service cloud.firestore {
     function isAdmin() {
       return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
     }
+    function appSettings() { return get(/databases/$(database)/documents/settings/app).data; }
+    function inUnit(doc) {
+      return !appSettings().multiUnit || isAdmin() || doc.data.unitId == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.unitId;
+    }
     match /users/{uid} {
       allow read: if signedIn() && (uid == request.auth.uid || isAdmin());
+      allow write: if isAdmin();
+    }
+    match /clientErrors/{id} {
+      allow create: if signedIn();
+      allow read: if isAdmin();
+      allow delete: if false;
+    }
+    match /settings/goals/{month} {
+      allow read: if signedIn();
+      allow write: if isAdmin();
+    }
+    match /units/{id} {
+      allow read: if signedIn();
       allow write: if isAdmin();
     }
     match /auditLogs/{id} {
@@ -14,7 +31,7 @@ service cloud.firestore {
       allow write: if false;
     }
     match /orders/{id} {
-      allow read: if signedIn();
+      allow read: if signedIn() && inUnit(resource);
       allow write: if isAdmin();
     }
     match /quotes_public/{token} {
@@ -22,7 +39,7 @@ service cloud.firestore {
       allow write: if false;
     }
     match /{document=**} {
-      allow read, write: if signedIn();
+      allow read, write: if signedIn() && inUnit(resource);
     }
   }
 }
@@ -38,3 +55,5 @@ service cloud.firestore {
 // quotes_public(token asc)
 // users(role asc)
 // services(createdAt desc)
+// clientErrors(route asc, ts desc)
+// orders(unitId asc, status asc)

--- a/public/index.html
+++ b/public/index.html
@@ -27,11 +27,17 @@
             <a href="#clientes">Clientes</a>
             <a href="#servicos">Serviços</a>
             <a href="#relatorios">Relatórios</a>
+            <a href="#relatorios-avancados" data-i18n="navbar.advancedReports">Relatórios Avançados</a>
             <a href="#usuarios" class="admin-only" style="display:none;">Usuários</a>
             <a href="#config" class="admin-only" style="display:none;">Config.</a>
+            <a href="#config/goals" class="admin-only" style="display:none;" data-i18n="navbar.goals">Metas</a>
+            <a href="#unidades" class="admin-only" style="display:none;" data-i18n="navbar.units">Unidades</a>
+            <a href="#dev/logs" class="admin-only" style="display:none;" data-i18n="navbar.logs">Logs</a>
+            <select id="unit-switcher" class="admin-only" style="display:none;"></select>
             <span id="whoami" class="muted"></span>
             <span id="net-status" class="offline-indicator" hidden>OFFLINE</span>
             <button id="themeToggle" class="link" type="button">Tema</button>
+            <button id="langToggle" class="link" type="button">Lang</button>
             <button id="btnSignOut" class="link">Sair</button>
         </nav>
     </header>

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -1,0 +1,126 @@
+// js/i18n.js
+const dictionaries = {
+  'pt-BR': {
+    navbar: {
+      advancedReports: 'Relatórios Avançados',
+      logs: 'Logs',
+      units: 'Unidades',
+      goals: 'Metas',
+      language: 'Idioma',
+    },
+    reports: {
+      advanced: {
+        title: 'Relatórios Avançados',
+      },
+      tabs: {
+        revenue: 'Receita por serviço',
+        customers: 'Clientes',
+        conversion: 'Conversão',
+        productivity: 'Produtividade',
+        heatmap: 'Mapa de calor',
+      },
+    },
+    goals: {
+      title: 'Metas',
+      revenueTarget: 'Meta de receita',
+      ordersTarget: 'Meta de ordens',
+      save: 'Salvar',
+    },
+    units: {
+      title: 'Unidades',
+      migration: 'Atribuir unidade padrão',
+    },
+    logs: {
+      title: 'Logs de Erro',
+      clear: 'Limpar antigos',
+    },
+    settings: {
+      general: 'Geral',
+    },
+    common: {
+      saved: 'Salvo',
+    },
+  },
+  'en-US': {
+    navbar: {
+      advancedReports: 'Advanced Reports',
+      logs: 'Logs',
+      units: 'Units',
+      goals: 'Goals',
+      language: 'Language',
+    },
+    reports: {
+      advanced: {
+        title: 'Advanced Reports',
+      },
+      tabs: {
+        revenue: 'Revenue by service',
+        customers: 'Customers',
+        conversion: 'Conversion',
+        productivity: 'Productivity',
+        heatmap: 'Heatmap',
+      },
+    },
+    goals: {
+      title: 'Goals',
+      revenueTarget: 'Revenue target',
+      ordersTarget: 'Orders target',
+      save: 'Save',
+    },
+    units: {
+      title: 'Units',
+      migration: 'Assign default unit',
+    },
+    logs: {
+      title: 'Error Logs',
+      clear: 'Clean old',
+    },
+    settings: {
+      general: 'General',
+    },
+    common: {
+      saved: 'Saved',
+    },
+  },
+};
+
+export let currentLang = localStorage.getItem('lang') || navigator.language || 'pt-BR';
+if (!dictionaries[currentLang]) currentLang = 'pt-BR';
+
+export function t(key, vars) {
+  const parts = key.split('.');
+  let str = parts.reduce((acc, k) => (acc && acc[k] !== undefined ? acc[k] : null), dictionaries[currentLang]);
+  if (typeof str !== 'string') str = key;
+  if (vars) {
+    Object.keys(vars).forEach(k => {
+      str = str.replace(`{${k}}`, vars[k]);
+    });
+  }
+  return str;
+}
+
+export function setLang(lang) {
+  if (!dictionaries[lang]) return;
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+  document.dispatchEvent(new CustomEvent('lang:changed', { detail: lang }));
+}
+
+export function applyTranslations(root = document) {
+  const elements = root.querySelectorAll('[data-i18n]');
+  elements.forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    el.textContent = t(key);
+  });
+}
+
+export function initLangToggle(btn) {
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const next = currentLang === 'pt-BR' ? 'en-US' : 'pt-BR';
+    setLang(next);
+  });
+  btn.textContent = t('navbar.language');
+}
+
+document.addEventListener('lang:changed', () => applyTranslations());

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,8 +1,39 @@
 // js/main.js
+// js/main.js
 import { navigate } from './router.js';
+import { applyTranslations, initLangToggle } from './i18n.js';
+import { logClientError } from './services/firestoreService.js';
+import { auth } from './firebase-config.js';
+
+function setupTelemetry() {
+  window.addEventListener('error', (e) => {
+    logClientError({
+      uid: auth.currentUser?.uid || null,
+      route: location.hash,
+      message: e.message,
+      stack: e.error?.stack || '',
+      ua: navigator.userAgent,
+      ts: new Date().toISOString(),
+    });
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    logClientError({
+      uid: auth.currentUser?.uid || null,
+      route: location.hash,
+      message: e.reason?.message || '',
+      stack: e.reason?.stack || '',
+      ua: navigator.userAgent,
+      ts: new Date().toISOString(),
+    });
+  });
+}
 
 const main = () => {
   window.addEventListener('hashchange', navigate);
+  document.addEventListener('lang:changed', () => applyTranslations());
+  applyTranslations();
+  initLangToggle(document.getElementById('langToggle'));
+  setupTelemetry();
   navigate();
 };
 

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -10,6 +10,10 @@ import { renderKanbanView } from './views/kanbanView.js';
 import { renderMyWorkView } from './views/myWorkView.js';
 import { renderQuotesView } from './views/quotesView.js';
 import { renderQuotePublicView } from './views/quotePublicView.js';
+import { renderReportsAdvancedView } from './views/reportsAdvancedView.js';
+import { renderGoalsView } from './views/goalsView.js';
+import { renderUnitsView } from './views/unitsView.js';
+import { renderDevLogsView } from './views/devLogsView.js';
 import { auth } from './firebase-config.js';
 
 const appContainer = document.getElementById('app-container');
@@ -38,8 +42,16 @@ const routes = {
   '#my-work': renderMyWorkView,
   '#orcamentos': renderQuotesView,
   '#relatorios': renderReportsView,
-  '#config': renderSettingsView,
+  '#relatorios-avancados': renderReportsAdvancedView,
+  '#config': (param) => {
+    if (param === 'goals') return renderGoalsView();
+    return renderSettingsView();
+  },
   '#usuarios': renderUsersView,
+  '#unidades': renderUnitsView,
+  '#dev': (param) => {
+    if (param === 'logs') renderDevLogsView();
+  },
   '#q': renderQuotePublicView,
 };
 
@@ -64,7 +76,7 @@ export function navigate() {
   const [mainPath, ...rest] = hash.split('/');
   const param = rest.join('/') || null;
 
-  const adminRoutes = ['#usuarios', '#config'];
+  const adminRoutes = ['#usuarios', '#config', '#dev', '#unidades'];
   const role = window.sessionState?.role;
   if (adminRoutes.includes(mainPath) && role !== 'admin') {
     location.hash = '#dashboard';

--- a/public/js/utils/virtualList.js
+++ b/public/js/utils/virtualList.js
@@ -1,0 +1,28 @@
+// utils/virtualList.js
+export function renderVirtualList({ container, total, itemHeight, renderWindow }) {
+  const phantom = document.createElement('div');
+  phantom.className = 'virtual-list-phantom';
+  phantom.style.height = `${total * itemHeight}px`;
+  container.classList.add('virtual-list-container');
+  container.innerHTML = '';
+  container.appendChild(phantom);
+
+  function update() {
+    const scrollTop = container.scrollTop;
+    const height = container.clientHeight;
+    const start = Math.floor(scrollTop / itemHeight);
+    const end = Math.min(total, start + Math.ceil(height / itemHeight) + 1);
+    phantom.innerHTML = '';
+    for (let i = start; i < end; i++) {
+      const item = document.createElement('div');
+      item.className = 'virtual-list-item';
+      item.style.top = `${i * itemHeight}px`;
+      renderWindow(i, item);
+      phantom.appendChild(item);
+    }
+  }
+
+  container.addEventListener('scroll', update);
+  update();
+}
+

--- a/public/js/views/devLogsView.js
+++ b/public/js/views/devLogsView.js
@@ -1,0 +1,17 @@
+import { t } from '../i18n.js';
+import { getClientErrors, cleanOldClientErrors } from '../services/firestoreService.js';
+
+export async function renderDevLogsView() {
+  const container = document.getElementById('app-container');
+  container.innerHTML = `<h2>${t('logs.title')}</h2><div id="logs-list" class="mt"></div><button id="btn-clean" class="btn btn-secondary mt">${t('logs.clear')}</button>`;
+
+  const listEl = container.querySelector('#logs-list');
+  const logs = await getClientErrors().catch(() => []);
+  listEl.innerHTML = logs.map(l => `<div class="card"><strong>${l.route}</strong><pre>${l.message}</pre></div>`).join('');
+
+  container.querySelector('#btn-clean').addEventListener('click', async () => {
+    await cleanOldClientErrors();
+    alert(t('common.saved'));
+  });
+}
+

--- a/public/js/views/goalsView.js
+++ b/public/js/views/goalsView.js
@@ -1,0 +1,30 @@
+import { t } from '../i18n.js';
+import { getGoals, setGoals } from '../services/firestoreService.js';
+
+export async function renderGoalsView() {
+  const container = document.getElementById('app-container');
+  const now = new Date();
+  const monthKey = now.toISOString().slice(0, 7); // YYYY-MM
+  const goals = await getGoals(monthKey).catch(() => ({}));
+
+  container.innerHTML = `
+    <h2>${t('goals.title')}</h2>
+    <form id="goals-form" class="grid">
+      <label>${t('goals.revenueTarget')}<input id="goal-revenue" type="number" class="input" value="${goals.revenueTarget || ''}" /></label>
+      <label>${t('goals.ordersTarget')}<input id="goal-orders" type="number" class="input" value="${goals.ordersTarget || ''}" /></label>
+      <button type="submit" class="btn btn-primary mt">${t('goals.save')}</button>
+    </form>
+  `;
+
+  const form = container.querySelector('#goals-form');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = {
+      revenueTarget: Number(container.querySelector('#goal-revenue').value) || 0,
+      ordersTarget: Number(container.querySelector('#goal-orders').value) || 0,
+    };
+    await setGoals(monthKey, data);
+    alert(t('common.saved'));
+  });
+}
+

--- a/public/js/views/reportsAdvancedView.js
+++ b/public/js/views/reportsAdvancedView.js
@@ -1,0 +1,26 @@
+import { t } from '../i18n.js';
+
+export function renderReportsAdvancedView() {
+  const container = document.getElementById('app-container');
+  container.innerHTML = `
+    <h2>${t('reports.advanced.title')}</h2>
+    <div class="tabs">
+      <button class="tab-btn" data-tab="revenue">${t('reports.tabs.revenue')}</button>
+      <button class="tab-btn" data-tab="customers">${t('reports.tabs.customers')}</button>
+      <button class="tab-btn" data-tab="conversion">${t('reports.tabs.conversion')}</button>
+      <button class="tab-btn" data-tab="productivity">${t('reports.tabs.productivity')}</button>
+      <button class="tab-btn" data-tab="heatmap">${t('reports.tabs.heatmap')}</button>
+    </div>
+    <div id="reports-advanced-content" class="mt"></div>
+  `;
+
+  const content = container.querySelector('#reports-advanced-content');
+  function show(tab) {
+    content.innerHTML = `<p>${t('reports.tabs.' + tab)} - TODO</p>`;
+  }
+  container.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => show(btn.dataset.tab));
+  });
+  show('revenue');
+}
+

--- a/public/js/views/settingsView.js
+++ b/public/js/views/settingsView.js
@@ -1,9 +1,14 @@
 import { exportCollections, importCollections } from '../services/firestoreService.js';
+import { t } from '../i18n.js';
 
 export function renderSettingsView() {
   const container = document.getElementById('app-container');
   container.innerHTML = `
     <h2>Configurações</h2>
+    <nav class="tabs mt">
+      <a href="#config" class="tab-btn" aria-selected="true">${t('settings.general')}</a>
+      <a href="#config/goals" class="tab-btn">${t('navbar.goals')}</a>
+    </nav>
     <section class="mt">
       <h3>Backup</h3>
       <button id="btn-backup" class="btn btn-primary">Exportar JSON</button>

--- a/public/js/views/unitsView.js
+++ b/public/js/views/unitsView.js
@@ -1,0 +1,24 @@
+import { t } from '../i18n.js';
+import { getUnits, setDefaultUnitForAll } from '../services/firestoreService.js';
+
+export async function renderUnitsView() {
+  const container = document.getElementById('app-container');
+  container.innerHTML = `<h2>${t('units.title')}</h2><div id="units-list" class="mt"></div>`;
+
+  const listEl = container.querySelector('#units-list');
+  const units = await getUnits().catch(() => []);
+  listEl.innerHTML = units.map(u => `<div class="card">${u.name}</div>`).join('');
+
+  // Placeholder for migration button
+  const btnMig = document.createElement('button');
+  btnMig.textContent = t('units.migration');
+  btnMig.className = 'btn btn-secondary mt';
+  btnMig.addEventListener('click', async () => {
+    const unitId = units[0]?.id;
+    if (!unitId) return;
+    await setDefaultUnitForAll(['customers', 'vehicles', 'services', 'orders'], unitId);
+    alert(t('common.saved'));
+  });
+  container.appendChild(btnMig);
+}
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -207,6 +207,37 @@ main#app-container {
     transition: transform 0.3s;
 }
 
+/* --- UTILITÁRIOS NOVOS --- */
+.progress-bar {
+    background: var(--border);
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.progress-bar span {
+    display: block;
+    height: 100%;
+    background: var(--brand);
+}
+
+.virtual-list-container {
+    position: relative;
+    overflow-y: auto;
+}
+.virtual-list-phantom {
+    position: relative;
+    width: 100%;
+}
+.virtual-list-item {
+    position: absolute;
+    width: 100%;
+}
+
+.heatmap {
+    display: grid;
+    gap: 2px;
+}
+
 .modal-overlay.active .modal-content {
     transform: scale(1);
 }


### PR DESCRIPTION
## Summary
- add i18n module and language toggle
- scaffold advanced reports, goals, units and log views
- extend firestore service with analytics helpers and client error logging
- update rules for clientErrors and multi-unit access

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d142d5a70832eb80a3d65cf57ed9d