### PR TITLE
Remove duplicate cacheKey declaration in Firestore service

### DIFF
--- a/public/js/services/firestoreService.js
+++ b/public/js/services/firestoreService.js
@@ -50,7 +50,6 @@ export async function getCustomers(opts = {}) {
 
   const arr = snap.docs.map(d => ({ id: d.id, ...d.data() }));
   arr.lastId = snap.docs.length ? snap.docs[snap.docs.length - 1].id : null;
-  const cacheKey = `customers_${unitId || 'all'}_${order}_${limitCount || 0}_${startAfterId || 'start'}`;
   memCache[cacheKey] = arr;
   return arr;
 }


### PR DESCRIPTION
## Summary
- avoid redeclaring `cacheKey` inside `getCustomers`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d16bcb008832e9765e39b56700ec1