### PR TITLE
feat: modernize app shell and forms

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,14 @@
     <header id="topbar" style="display:none;">
         <span class="brand">Minha Estética</span>
         <input id="global-search" type="search" class="input" placeholder="Buscar cliente, placa, OS…" />
-        <button id="btn-new" class="btn btn-primary">Novo</button>
+        <div class="new-area">
+            <button id="btn-new" class="btn btn-primary">Novo</button>
+            <div id="new-menu" class="menu hidden">
+                <a href="#orders" data-route="#orders">Nova OS</a>
+                <a href="#clientes" data-route="#clientes">Novo Cliente</a>
+                <a href="#orcamentos" data-route="#orcamentos">Novo Orçamento</a>
+            </div>
+        </div>
         <div class="user-area">
             <button id="user-btn" class="link"><span id="whoami"></span></button>
             <div id="user-menu" class="menu hidden">
@@ -64,13 +71,6 @@
             </div>
         </nav>
     </aside>
-
-    <nav id="bottom-nav" style="display:none;">
-        <a href="#dashboard" data-route="#dashboard">Dashboard</a>
-        <a href="#agenda" data-route="#agenda">Agenda</a>
-        <a href="#orders" data-route="#orders">Ordens</a>
-        <a href="#clientes" data-route="#clientes">Clientes</a>
-    </nav>
 
     <section id="page-header" style="display:none;"></section>
     <main id="page-content"></main>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -37,7 +37,6 @@ const showPassBtns = document.querySelectorAll('.show-pass-btn');
 
 const topbar = document.getElementById('topbar');
 const sidebar = document.getElementById('sidebar');
-const bottomNav = document.getElementById('bottom-nav');
 const whoami = document.getElementById('whoami');
 const appContainer = document.getElementById('page-content');
 const btnSignOut = document.getElementById('btnSignOut');
@@ -214,7 +213,6 @@ onAuthStateChanged(auth, async (user) => {
     whoami.textContent = user.email;
     sidebar.style.display = '';
     topbar.style.display = '';
-    bottomNav.style.display = '';
     authShell.style.display = 'none';
     if (location.hash === '#login' || !location.hash) {
       location.hash = '#dashboard';
@@ -230,7 +228,6 @@ onAuthStateChanged(auth, async (user) => {
     whoami.textContent = '';
     sidebar.style.display = 'none';
     topbar.style.display = 'none';
-    bottomNav.style.display = 'none';
     authShell.style.display = '';
     appContainer.innerHTML = '';
     if (location.hash !== '#login') {

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -20,12 +20,12 @@ import { auth } from './firebase-config.js';
 const appContainer = document.getElementById('page-content');
 const pageHeader = document.getElementById('page-header');
 const netStatus = document.getElementById('net-status');
-const sidebarLinks = document.querySelectorAll('#sidebar a[data-route],#bottom-nav a[data-route]');
+const sidebarLinks = document.querySelectorAll('#sidebar a[data-route]');
 const globalSearch = document.getElementById('global-search');
 
 window.setPageHeader = ({ title = '', breadcrumbs = [], actions = [], filters = '' }) => {
   const crumbs = breadcrumbs.length ? `<nav class="breadcrumbs">${breadcrumbs.join(' / ')}</nav>` : '';
-  const acts = actions.map(a => `<button class="btn" id="${a.id}">${a.label}</button>`).join('');
+  const acts = actions.slice(0,2).map(a => `<button class="btn ${a.variant || 'btn-primary'}" id="${a.id}">${a.label}</button>`).join('');
   pageHeader.innerHTML = `
     ${crumbs}
     <div class="header-main">
@@ -114,9 +114,7 @@ export function navigate() {
 
   sidebarLinks.forEach(link => link.classList.remove('active'));
   const activeLink = document.querySelector(`#sidebar a[data-route="${mainPath}"]`);
-  const activeBottom = document.querySelector(`#bottom-nav a[data-route="${mainPath}"]`);
   activeLink?.classList.add('active');
-  activeBottom?.classList.add('active');
 
   const fn = routes[mainPath];
   if (typeof fn === 'function') {

--- a/public/js/views/clientesView.js
+++ b/public/js/views/clientesView.js
@@ -21,26 +21,47 @@ export const renderClientesView = async (maybeId) => {
   customers = [];
   lastId = null;
 
+  setPageHeader({ title: 'Clientes' });
+
   appContainer.innerHTML = `
-    <section class="card">
-      <h2>Clientes</h2>
+    <div class="card" style="max-width:480px;margin-bottom:var(--space-6);">
       <div id="clientes-alert" class="alert" aria-live="polite"></div>
-      <form id="form-new-customer" class="grid mt" aria-busy="false">
-        <label>Nome <input id="cName" type="text" required /></label>
-        <label>Telefone <input id="cPhone" type="tel" required /></label>
-        <label>Email (opcional) <input id="cEmail" type="email" /></label>
-        <button class="btn">Adicionar</button>
+      <form id="form-new-customer" class="stack" aria-busy="false">
+        <div class="form-row">
+          <label for="cName">Nome</label>
+          <input id="cName" class="input" type="text" required />
+        </div>
+        <div class="form-row">
+          <label for="cPhone">Telefone</label>
+          <input id="cPhone" class="input" type="tel" required />
+        </div>
+        <div class="form-row">
+          <label for="cEmail">Email (opcional)</label>
+          <input id="cEmail" class="input" type="email" />
+        </div>
+        <div class="form-row" style="justify-content:flex-end;">
+          <button class="btn btn-primary">Adicionar</button>
+        </div>
       </form>
-      <div class="grid mt">
-        <input id="search" class="input" type="search" placeholder="Buscar" />
+    </div>
+
+    <div class="card" style="max-width:480px;margin-bottom:var(--space-6);">
+      <div class="form-row">
+        <div class="input-icon" style="flex:1;">
+          <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707 1.414-1.414-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z"/>
+          </svg>
+          <input id="search" class="input" type="search" placeholder="Buscar" />
+        </div>
         <select id="sort" class="input">
           <option value="date">Mais recentes</option>
           <option value="name">A–Z</option>
         </select>
       </div>
-      <div id="customers-list" class="mt"></div>
-      <button class="btn mt" id="load-more" hidden>Carregar mais</button>
-    </section>
+    </div>
+
+    <div id="customers-list" class="card-list"></div>
+    <button class="btn btn-secondary mt" id="load-more" hidden>Carregar mais</button>
   `;
 
   document.getElementById('form-new-customer').onsubmit = onAddCustomer;
@@ -104,15 +125,17 @@ function renderCustomerList() {
   }
 
   if (!list.length) {
-    container.innerHTML = '<p class="muted">Nenhum cliente encontrado.</p>';
+    container.innerHTML = `
+      <div class="empty-state">
+        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zM2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12zm11 5v-2h-2v2h2zm0-4V7h-2v6h2z"/></svg>
+        <p>Nenhum cliente encontrado</p>
+        <button id="empty-add" class="btn btn-primary">Adicionar cliente</button>
+      </div>`;
+    document.getElementById('empty-add').onclick = () => document.getElementById('cName').focus();
     return;
   }
 
-  container.innerHTML = `
-    <div class="grid-2">
-      ${list.map(renderCard).join('')}
-    </div>
-  `;
+  container.innerHTML = list.map(renderCard).join('');
 
   list.forEach(c => updateVehicleBadge(c.id));
   container.onclick = onListClick;
@@ -216,29 +239,34 @@ async function renderCustomerDetail(customerId) {
     return;
   }
   const vehicles = await getVehiclesForCustomer(customerId);
+  setPageHeader({ title: esc(c.name || 'Cliente'), breadcrumbs: ['<a href="#clientes">Clientes</a>', esc(c.name || 'Cliente')] });
 
   appContainer.innerHTML = `
-    <section class="card">
-      <button class="link" id="back">&larr; Voltar</button>
-      <h2>${esc(c.name || 'Cliente')}</h2>
+    <div class="card">
       <p class="muted">${esc(c.phone || '')}${c.email ? ' · ' + esc(c.email) : ''}</p>
       <div id="clientes-alert" class="alert" aria-live="polite"></div>
 
       <h3 class="mt">Veículos</h3>
-      <form id="form-vehicle" class="grid mt" aria-busy="false">
-        <label>Placa <input id="vPlate" required /></label>
-        <label>Modelo <input id="vModel" required /></label>
-        <button class="btn">Adicionar veículo</button>
+      <form id="form-vehicle" class="stack mt" aria-busy="false" style="max-width:480px;">
+        <div class="form-row">
+          <label for="vPlate">Placa</label>
+          <input id="vPlate" class="input" required />
+        </div>
+        <div class="form-row">
+          <label for="vModel">Modelo</label>
+          <input id="vModel" class="input" required />
+        </div>
+        <div class="form-row" style="justify-content:flex-end;">
+          <button class="btn btn-primary">Adicionar veículo</button>
+        </div>
       </form>
 
       <ul id="vehicles" class="list mt"></ul>
       <div class="card-actions mt">
         <button class="link" id="delCustomer">Excluir cliente</button>
       </div>
-    </section>
+    </div>
   `;
-
-  document.getElementById('back').onclick = () => { location.hash = '#clientes'; };
   document.getElementById('form-vehicle').onsubmit = async (e) => {
     e.preventDefault();
     const form = e.target;

--- a/public/js/views/servicosView.js
+++ b/public/js/views/servicosView.js
@@ -7,18 +7,40 @@ let servicos = [];
 
 export const renderServicosView = async () => {
   servicos = await getServicos();
+  setPageHeader({ title: 'Serviços' });
   appContainer.innerHTML = `
-    <section class="card">
-      <h2>Serviços</h2>
+    <div class="card" style="max-width:480px;margin-bottom:var(--space-6);">
       <div id="s-alert" class="alert" aria-live="polite"></div>
-      <form id="form-servico" class="grid mt" aria-busy="false">
-        <label>Nome* <input id="sName" required /></label>
-        <label>Preço* <input id="sPrice" type="number" min="0" step="0.01" required /></label>
-        <button class="btn">Adicionar</button>
+      <form id="form-servico" class="stack" aria-busy="false">
+        <div class="form-row">
+          <label for="sName">Nome*</label>
+          <input id="sName" class="input" required />
+        </div>
+        <div class="form-row">
+          <label for="sPrice">Preço*</label>
+          <input id="sPrice" class="input" type="number" min="0" step="0.01" required />
+        </div>
+        <div class="form-row" style="justify-content:flex-end;">
+          <button class="btn btn-primary">Adicionar</button>
+        </div>
       </form>
-      <input id="sSearch" class="input mt" type="search" placeholder="Buscar por nome" />
-      <div id="servicos-list" class="mt"></div>
-    </section>
+    </div>
+
+    <div class="card" style="max-width:480px;margin-bottom:var(--space-6);">
+      <div class="input-icon">
+        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707 1.414-1.414-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z"/>
+        </svg>
+        <input id="sSearch" class="input" type="search" placeholder="Buscar por nome" />
+      </div>
+    </div>
+
+    <div class="card">
+      <table class="table compact listrada">
+        <thead><tr><th>Nome</th><th>Preço</th><th></th></tr></thead>
+        <tbody id="servicos-list"></tbody>
+      </table>
+    </div>
   `;
   document.getElementById('form-servico').onsubmit = onAddServico;
   document.getElementById('sSearch').addEventListener('input', renderList);
@@ -51,21 +73,24 @@ async function onAddServico(e) {
 
 function renderList() {
   const term = document.getElementById('sSearch').value.toLowerCase();
-  const listEl = document.getElementById('servicos-list');
+  const body = document.getElementById('servicos-list');
   const filtered = term ? servicos.filter(s => (s.name||'').toLowerCase().includes(term)) : servicos;
-  listEl.innerHTML = filtered.map(s => `
-    <div class="simple-list-item">
-      <div>
-        <strong>${esc(s.name||'-')}</strong><br/>
-        <small class="muted">R$ ${(Number(s.price)||0).toFixed(2)} • ${formatDate(s.createdAt)}</small>
-      </div>
-      <div>
-        <button class="btn btn-sm" data-edit="${s.id}">Editar</button>
+  if (!filtered.length) {
+    body.innerHTML = `<tr><td colspan="3"><div class="empty-state"><svg viewBox='0 0 24 24' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a10 10 0 100 20 10 10 0 000-20zM2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12zm11 5v-2h-2v2h2zm0-4V7h-2v6h2z'/></svg><p>Nenhum serviço.</p><button id='empty-servico' class='btn btn-primary'>Adicionar serviço</button></div></td></tr>`;
+    document.getElementById('empty-servico').onclick = () => document.getElementById('sName').focus();
+    return;
+  }
+  body.innerHTML = filtered.map(s => `
+    <tr>
+      <td>${esc(s.name||'-')}</td>
+      <td>R$ ${(Number(s.price)||0).toFixed(2)}</td>
+      <td>
+        <button class="btn btn-secondary" data-edit="${s.id}">Editar</button>
         <button class="link" data-del="${s.id}">Excluir</button>
-      </div>
-    </div>
-  `).join('') || '<p class="muted">Nenhum serviço.</p>';
-  listEl.onclick = onListClick;
+      </td>
+    </tr>
+  `).join('');
+  body.onclick = onListClick;
 }
 
 function onListClick(e) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,86 +1,71 @@
 /* --- DESIGN TOKENS --- */
 :root {
-  /* palette */
-  --neutral-0:#fff;
-  --neutral-50:#f8fafc;
-  --neutral-100:#f1f5f9;
-  --neutral-200:#e2e8f0;
-  --neutral-300:#cbd5e1;
-  --neutral-400:#94a3b8;
-  --neutral-500:#64748b;
-  --neutral-600:#475569;
-  --neutral-700:#334155;
-  --neutral-800:#1e293b;
-  --neutral-900:#0f172a;
+  /* base colors */
+  --neutral-0:#FFFFFF;
+  --neutral-50:#F7F8FB;
+  --neutral-100:#EFF1F5;
+  --neutral-200:#E6E8F0;
+  --neutral-900:#0F172A;
 
-  --brand-500:#1e40af;
-  --brand-600:#1e3a8a;
-  --success-500:#16a34a;
-  --warning-500:#d97706;
-  --danger-500:#dc2626;
-  --info-500:#2563eb;
-  --success-bg:#dcfce7;
-  --warning-bg:#fef9c3;
-  --danger-bg:#fee2e2;
-  --info-bg:#dbeafe;
+  --bg:#F7F8FB;
+  --card:#FFFFFF;
+  --border:#E6E8F0;
+  --fg:#0F172A;
+  --muted:#6B7280;
+  --accent:#2563EB;
+  --info:#3B82F6;
+  --warning:#F59E0B;
+  --success:#10B981;
+  --danger:#EF4444;
+  --info-bg:#DBEAFE;
+  --warning-bg:#FEF3C7;
+  --success-bg:#D1FAE5;
+  --danger-bg:#FEE2E2;
 
-  /* semantic */
-  --bg:var(--neutral-50);
-  --card:var(--neutral-0);
-  --border:var(--neutral-200);
-  --fg:var(--neutral-900);
-  --muted:var(--neutral-500);
-  --brand:var(--brand-600);
   --primary:var(--fg);
-  --primary-contrast:var(--neutral-0);
-  --ring:var(--info-500);
-  --success:var(--success-500);
-  --warning:var(--warning-500);
-  --danger:var(--danger-500);
-  --info:var(--info-500);
+  --primary-contrast:#FFFFFF;
+  --ring:rgba(37,99,235,.3);
 
   /* radii */
-  --radius-sm:8px;
-  --radius-md:12px;
-  --radius-lg:20px;
+  --radius-sm:8px; /* inputs/buttons */
+  --radius-md:12px; /* cards */
 
-  /* shadows */
-  --shadow-xs:0 1px 2px rgba(0,0,0,.05);
-  --shadow-sm:0 2px 4px rgba(0,0,0,.1);
-  --shadow-md:0 4px 6px rgba(0,0,0,.1);
-  --shadow-lg:0 8px 12px rgba(0,0,0,.15);
+  /* shadow */
+  --shadow-sm:0 1px 2px rgba(16,24,40,.06);
+  --shadow-md:0 2px 4px rgba(16,24,40,.08);
+  --shadow-lg:0 4px 8px rgba(16,24,40,.1);
 
-  /* spacing */
+  /* spacing scale */
   --space-1:4px;
   --space-2:8px;
   --space-3:12px;
   --space-4:16px;
   --space-5:24px;
   --space-6:32px;
+  --space-7:48px;
 
-  /* type scale */
+  /* typography */
   --font-12:0.75rem;
   --font-14:0.875rem;
   --font-16:1rem;
-  --font-18:1.125rem;
   --font-20:1.25rem;
   --font-24:1.5rem;
   --font-28:1.75rem;
-  --font-32:2rem;
   --line-base:1.5;
+
   --topbar-h:56px;
-  --sidebar-w:240px;
-  --sidebar-collapsed:80px;
+  --sidebar-w:248px;
+  --sidebar-collapsed:72px;
 }
 
 [data-theme="dark"] {
-  --bg:var(--neutral-900);
-  --card:var(--neutral-800);
-  --border:var(--neutral-700);
-  --fg:var(--neutral-100);
-  --muted:var(--neutral-400);
-  --primary:var(--fg);
-  --primary-contrast:var(--neutral-900);
+  --bg:#0B1220;
+  --card:#111827;
+  --border:#1F2937;
+  --fg:#E5E7EB;
+  --muted:#9CA3AF;
+  --accent:#3B82F6;
+  --ring:rgba(59,130,246,.3);
 }
 
 /* --- RESET --- */
@@ -97,6 +82,8 @@ body{
   transition:background-color .2s,color .2s;
 }
 
+label{font-size:var(--font-12);font-weight:600;text-transform:uppercase;letter-spacing:0.04em;}
+
 #topbar{
   position:fixed;
   top:0;left:0;right:0;
@@ -109,7 +96,7 @@ body{
   border-bottom:1px solid var(--border);
   z-index:100;
 }
-#topbar .brand{color:var(--brand);font-weight:600;}
+#topbar .brand{color:var(--accent);font-weight:600;}
 #topbar input[type="search"]{flex:1;max-width:400px;}
 
 #sidebar{
@@ -125,8 +112,9 @@ body{
 }
 #sidebar.is-collapsed{width:var(--sidebar-collapsed);}
 #sidebar .nav-group h3{font-size:var(--font-12);margin:var(--space-4) 0 var(--space-2);color:var(--muted);} 
-#sidebar a{display:block;padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;color:var(--primary);}
-#sidebar a.active,#sidebar a:hover{background:var(--info-bg);color:var(--info);}
+#sidebar a{display:block;padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);text-decoration:none;color:var(--primary);position:relative;}
+#sidebar a:hover{background:var(--info-bg);}
+#sidebar a.active{color:var(--accent);background:var(--card);box-shadow:inset 4px 0 0 var(--accent);}
 
 #page-header{
   position:sticky;
@@ -143,15 +131,11 @@ body{
 #page-header .actions button{margin-left:var(--space-2);}
 #page-header .filters{margin-top:var(--space-3);}
 
-#page-content{margin-left:var(--sidebar-w);padding:var(--space-5);} 
-
-#bottom-nav{display:none;}
+#page-content{margin-left:var(--sidebar-w);padding:var(--space-5);max-width:1200px;}
 
 @media (max-width:768px){
   #sidebar{display:none;}
   #page-content,#page-header{margin-left:0;}
-  #bottom-nav{display:flex;position:fixed;bottom:0;left:0;right:0;height:56px;background:var(--card);border-top:1px solid var(--border);justify-content:space-around;align-items:center;}
-  #bottom-nav a{flex:1;text-align:center;padding:var(--space-2);text-decoration:none;color:var(--primary);}
 }
 
 /* --- FEEDBACK --- */
@@ -176,6 +160,9 @@ body{
   font-size:var(--font-12);
   margin-left:.5rem;
 }
+.menu{position:absolute;top:100%;right:0;background:var(--card);border:1px solid var(--border);border-radius:var(--radius-sm);box-shadow:var(--shadow-md);display:flex;flex-direction:column;min-width:160px;}
+.menu.hidden{display:none;}
+.menu a,.menu button{background:none;border:none;text-align:left;padding:var(--space-2) var(--space-3);cursor:pointer;color:var(--primary);text-decoration:none;}
 .skeleton{
   background:var(--neutral-200);
   height:1rem;
@@ -201,11 +188,12 @@ main#page-content{padding:var(--space-5);}
   cursor:pointer;
   transition:background-color .15s,color .15s,filter .15s;
 }
-.btn-primary{background:var(--info);color:var(--primary-contrast);}
+.btn-primary{background:var(--accent);color:var(--primary-contrast);}
 .btn-secondary{background:var(--border);color:var(--primary);}
 .btn-ghost{background:transparent;color:var(--primary);}
 .btn-danger{background:var(--danger);color:var(--primary-contrast);}
-.btn:hover,.btn:focus-visible{filter:brightness(.9);}
+.btn:hover{filter:brightness(.9);}
+.btn:focus-visible{box-shadow:0 0 0 3px var(--ring);}
 .btn:disabled{opacity:.6;cursor:not-allowed;}
 .btn.loading{pointer-events:none;opacity:.7;}
 .spinner{width:16px;height:16px;border:2px solid var(--primary-contrast);border-bottom-color:transparent;border-radius:50%;animation:spin 1s linear infinite;}
@@ -214,8 +202,8 @@ main#page-content{padding:var(--space-5);}
 .card{
   background:var(--card);
   padding:var(--space-4);
-  border-radius:var(--radius-sm);
-  box-shadow:var(--shadow-xs);
+  border-radius:var(--radius-md);
+  box-shadow:var(--shadow-sm);
   border:1px solid var(--border);
 }
 
@@ -247,17 +235,24 @@ main#page-content{padding:var(--space-5);}
   transition:border-color .2s,box-shadow .2s;
 }
 .input:focus-visible,select:focus-visible,textarea:focus-visible{
-  outline:2px solid var(--ring);
-  outline-offset:2px;
+  outline:none;
+  box-shadow:0 0 0 3px var(--ring);
 }
 
 .form-row{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-bottom:var(--space-3);}
 .table{width:100%;border-collapse:collapse;margin-top:var(--space-4);}
-.table th,.table td{border:1px solid var(--border);padding:var(--space-2);text-align:left;}
-.table.striped tbody tr:nth-child(odd){background:var(--neutral-50);}
+.table th,.table td{border:1px solid var(--border);padding:var(--space-3);text-align:left;}
+.table.compact th,.table.compact td{padding:var(--space-2);}
+.table.listrada tbody tr:nth-child(odd){background:var(--neutral-50);}
 .progress{background:var(--border);height:8px;border-radius:4px;overflow:hidden;}
-.progress span{display:block;height:100%;background:var(--brand);}
+.progress span{display:block;height:100%;background:var(--accent);}
 .empty-state{text-align:center;padding:var(--space-6) 0;color:var(--muted);}
+
+.input-icon{position:relative;}
+.input-icon svg{position:absolute;left:8px;top:50%;transform:translateY(-50%);width:16px;height:16px;color:var(--muted);}
+.input-icon input{padding-left:32px;}
+
+.card-actions{display:flex;gap:var(--space-2);margin-top:var(--space-3);}
 
 /* Modal */
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;justify-content:center;align-items:center;z-index:1000;opacity:0;visibility:hidden;transition:opacity .2s,visibility .2s;}
@@ -304,10 +299,10 @@ main#page-content{padding:var(--space-5);}
 .upload-item{margin-top:var(--space-2);}
 
 /* calendar overrides */
-#calendar-container{background:var(--card);padding:var(--space-5);border-radius:var(--radius-sm);box-shadow:var(--shadow-xs);}
+#calendar-container{background:var(--card);padding:var(--space-5);border-radius:var(--radius-md);box-shadow:var(--shadow-sm);}
 .fc .fc-col-header-cell-cushion{color:var(--info);text-decoration:none;}
-.fc .fc-button-primary{background:var(--info);border-color:var(--info);}
-.fc .fc-button-primary:hover{background:var(--brand-500);border-color:var(--brand-500);}
+.fc .fc-button-primary{background:var(--accent);border-color:var(--accent);}
+.fc .fc-button-primary:hover{filter:brightness(.9);}
 .fc-event{cursor:pointer;}
 
 /* utilities */


### PR DESCRIPTION
## Summary
- overhaul app shell with topbar, collapsible sidebar and page header
- introduce design tokens and reusable components for light/dark themes
- refactor Clientes and Serviços views to use new cards, forms, tables and empty states

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd functions && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e4e80f928832e9f53b1d4ca6e044d