### PR TITLE
style: unify UI elements across views

### DIFF
--- a/public/js/views/agendaView.js
+++ b/public/js/views/agendaView.js
@@ -7,18 +7,24 @@ const modalPlaceholder = document.getElementById('modal-placeholder');
 let calendar;
 
 export const renderAgendaView = async () => {
+  window.setPageHeader({
+    title: 'Agenda',
+    breadcrumbs: ['Operação', 'Agenda'],
+    filters: `
+      <div class="grid">
+        <input id="searchAgenda" placeholder="Cliente ou placa" />
+        <input type="date" id="agFrom" />
+        <input type="date" id="agTo" />
+      </div>`
+  });
   appContainer.innerHTML = `
-    <section>
-      <h2>Agenda</h2>
-      <div class="grid mt">
-        <input id="searchAgenda" placeholder="Buscar cliente/placa" />
-        <div>
-          <button class="btn" id="viewMonth">Mês</button>
-          <button class="btn" id="viewWeek">Semana</button>
-          <button class="btn" id="viewDay">Dia</button>
-        </div>
+    <section class="card">
+      <div>
+        <button class="btn" id="viewMonth">Mês</button>
+        <button class="btn" id="viewWeek">Semana</button>
+        <button class="btn" id="viewDay">Dia</button>
       </div>
-      <div id="calendar-container" class="card" style="padding:8px"></div>
+      <div id="calendar-container" style="padding:8px"></div>
       <div class="mt"><button class="btn" id="btnNewEvent">Novo agendamento</button></div>
     </section>
   `;
@@ -84,14 +90,23 @@ export const renderAgendaView = async () => {
   document.getElementById('viewWeek').onclick = ()=>calendar.changeView('timeGridWeek');
   document.getElementById('viewDay').onclick = ()=>calendar.changeView('timeGridDay');
   const search = document.getElementById('searchAgenda');
-  search.oninput = () => {
+  const fromInput = document.getElementById('agFrom');
+  const toInput = document.getElementById('agTo');
+  const applyFilters = () => {
     const t = search.value.toLowerCase();
+    const from = fromInput.value ? new Date(fromInput.value) : null;
+    const to = toInput.value ? new Date(toInput.value) : null;
     calendar.getEvents().forEach(ev => {
       const { customerName, plate } = ev.extendedProps;
-      const match = customerName.toLowerCase().includes(t) || plate.toLowerCase().includes(t);
-      ev.setProp('display', match ? 'auto' : 'none');
+      const matchText = customerName.toLowerCase().includes(t) || plate.toLowerCase().includes(t);
+      const st = ev.start;
+      const matchDate = (!from || st >= from) && (!to || st <= to);
+      ev.setProp('display', matchText && matchDate ? 'auto' : 'none');
     });
   };
+  search.oninput = applyFilters;
+  fromInput.onchange = applyFilters;
+  toInput.onchange = applyFilters;
 };
 
 async function openNewModal(start=null, end=null) {

--- a/public/js/views/kanbanView.js
+++ b/public/js/views/kanbanView.js
@@ -1,33 +1,51 @@
 // js/views/kanbanView.js
-import { getOrdersByStatus, updateOrdersKanban, setOrderAssignedTo, countOrderPhotos } from '../services/firestoreService.js';
+import { getOrdersByStatus, updateOrdersKanban, setOrderAssignedTo, countOrderPhotos, getCustomerById, getVehicleById } from '../services/firestoreService.js';
 import { auth } from '../firebase-config.js';
 
 const appContainer = document.getElementById('page-content');
 
 export async function renderKanbanView() {
+  window.setPageHeader({ title: 'Kanban', breadcrumbs: ['Operação', 'Kanban'] });
   appContainer.innerHTML = `
     <section class="card">
-      <h2>Kanban</h2>
       <div id="kanban-board" class="kanban-board"></div>
     </section>
   `;
   const statuses = ['novo','em_andamento','concluido','cancelado'];
   const board = document.getElementById('kanban-board');
+  const customerCache = {}, vehicleCache = {};
+  const wip = { em_andamento:5 };
   for (const st of statuses) {
     const col = document.createElement('div');
     col.className = 'kanban-col';
     col.dataset.status = st;
-    col.innerHTML = `<h3>${st}</h3><div class="kanban-items" id="col-${st}"></div>`;
+    col.innerHTML = `<div class="kanban-col-header">${st} (<span id="cnt-${st}">0</span>${wip[st]?`/${wip[st]}`:''})</div><div class="kanban-items" id="col-${st}"></div>`;
     board.appendChild(col);
     const orders = await getOrdersByStatus(st);
     const listEl = col.querySelector('.kanban-items');
-    listEl.innerHTML = orders.map(o=>`<div class="kanban-card" draggable="true" data-id="${o.id}">${o.id}</div>`).join('');
+    let html = '';
+    for (const o of orders) {
+      if (!customerCache[o.customerId]) customerCache[o.customerId] = (await getCustomerById(o.customerId))?.name || '';
+      if (o.vehicleId && !vehicleCache[o.vehicleId]) vehicleCache[o.vehicleId] = (await getVehicleById(o.vehicleId))?.plate || '';
+      const photos = await countOrderPhotos(o.id);
+      html += `<div class="kanban-card" draggable="true" data-id="${o.id}">
+        <div>${esc(customerCache[o.customerId]||'')}</div>
+        <div class="text-sm">${esc(vehicleCache[o.vehicleId]||'')}</div>
+        <div class="text-sm">${formatDate(o.scheduledStart)}</div>
+        <div class="text-sm">R$ ${(Number(o.total)||0).toFixed(2)} ${photos?'<span class="muted">📎</span>':''}</div>
+      </div>`;
+    }
+    listEl.innerHTML = html;
+    document.getElementById(`cnt-${st}`).textContent = orders.length;
   }
   // simples drag and drop
   let dragId = null;
   board.addEventListener('dragstart', e=>{
     const card = e.target.closest('.kanban-card');
-    if(card){ dragId = card.dataset.id; }
+    if(card){ dragId = card.dataset.id; card.classList.add('dragging'); }
+  });
+  board.addEventListener('dragend', e=>{
+    e.target.closest('.kanban-card')?.classList.remove('dragging');
   });
   board.addEventListener('dragover', e=>{
     if(e.target.classList.contains('kanban-items')) e.preventDefault();
@@ -36,11 +54,18 @@ export async function renderKanbanView() {
     const list = e.target.closest('.kanban-items');
     if(list && dragId){
       const status = list.parentElement.dataset.status;
+      const card = document.querySelector(`[data-id="${dragId}"]`);
+      const prevStatus = card.parentElement.parentElement.dataset.status;
+      list.appendChild(card);
       const cards = Array.from(list.children);
-      list.appendChild(document.querySelector(`[data-id="${dragId}"]`));
-      const updates = cards.concat(document.querySelector(`[data-id="${dragId}"]`)).map((c,i)=>({id:c.dataset.id,status,kanbanOrder:i}));
+      const updates = cards.map((c,i)=>({id:c.dataset.id,status,kanbanOrder:i}));
       await updateOrdersKanban(updates);
+      document.getElementById(`cnt-${status}`).textContent = cards.length;
+      document.getElementById(`cnt-${prevStatus}`).textContent = document.querySelectorAll(`#col-${prevStatus} .kanban-card`).length;
       dragId=null;
     }
   });
 }
+
+const esc  = (s='') => s.replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+const formatDate = ts => ts?.seconds ? new Date(ts.seconds*1000).toLocaleDateString() : '';

--- a/public/js/views/reportsView.js
+++ b/public/js/views/reportsView.js
@@ -2,18 +2,20 @@ import { Timestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-f
 import { getOrdersFinished, countOrdersByStatus, getCycleDurations } from '../services/firestoreService.js';
 
 export async function renderReportsView() {
+  window.setPageHeader({ title: 'Relatórios', breadcrumbs: ['Operação', 'Relatórios'] });
   const container = document.getElementById('page-content');
   container.innerHTML = `
-    <h2>Relatórios</h2>
-    <div class="tabs">
-      <button id="tab-fin" class="btn btn-secondary">Financeiro</button>
-      <button id="tab-op" class="btn btn-secondary">Operacional</button>
-    </div>
+    <nav class="tabs">
+      <button id="tab-fin" class="tab active">Financeiro</button>
+      <button id="tab-op" class="tab">Operacional</button>
+    </nav>
     <section id="report-content" aria-live="polite" class="mt"></section>
   `;
 
-  document.getElementById('tab-fin').addEventListener('click', () => loadFinanceiro());
-  document.getElementById('tab-op').addEventListener('click', () => loadOperacional());
+  const finBtn = document.getElementById('tab-fin');
+  const opBtn = document.getElementById('tab-op');
+  finBtn.addEventListener('click', () => { finBtn.classList.add('active'); opBtn.classList.remove('active'); loadFinanceiro(); });
+  opBtn.addEventListener('click', () => { opBtn.classList.add('active'); finBtn.classList.remove('active'); loadOperacional(); });
   loadFinanceiro();
 }
 
@@ -24,7 +26,7 @@ async function loadFinanceiro() {
   const from = Timestamp.fromDate(new Date(Date.now() - 7*86400000));
   const orders = await getOrdersFinished({ from, to });
   if (!orders.length) {
-    area.innerHTML = '<p>Nenhuma OS concluída.</p>';
+    area.innerHTML = '<p class="empty-state">Nenhuma OS concluída.</p>';
     return;
   }
   const totals = {};
@@ -36,11 +38,11 @@ async function loadFinanceiro() {
     totals[day].discount += Number(o.discount || 0);
     totals[day].total += Number(o.total || 0);
   });
-  let html = '<table class="table"><thead><tr><th>Dia</th><th>Qtd</th><th>Subtotal</th><th>Desc.</th><th>Total</th></tr></thead><tbody>';
+  let html = '<table class="table compact listrada sticky"><thead><tr><th>Dia</th><th>Qtd</th><th>Subtotal</th><th>Desc.</th><th>Total</th></tr></thead><tbody>';
   Object.entries(totals).forEach(([day,val]) => {
     html += `<tr><td>${day}</td><td>${val.count}</td><td>${val.subtotal.toFixed(2)}</td><td>${val.discount.toFixed(2)}</td><td>${val.total.toFixed(2)}</td></tr>`;
   });
-  html += '</tbody></table><button id="fin-csv" class="btn btn-primary mt">Exportar CSV</button>';
+  html += '</tbody></table><button id="fin-csv" class="btn btn-primary mt"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 0v8"/><path d="M4 4l4 4 4-4"/><path d="M4 12h8v2H4z"/></svg>Exportar CSV</button>';
   area.innerHTML = html;
   document.getElementById('fin-csv').addEventListener('click', () => {
     const rows = [['dia','qtd','subtotal','desconto','total']];
@@ -62,12 +64,16 @@ async function loadOperacional() {
   const from = Timestamp.fromDate(new Date(Date.now() - 7*86400000));
   const status = await countOrdersByStatus({ from, to });
   const cycle = await getCycleDurations({ from, to });
+  if (Object.keys(status).length === 0) {
+    area.innerHTML = '<p class="empty-state">Sem dados.</p>';
+    return;
+  }
   let html = '<div class="grid">';
   Object.entries(status).forEach(([st,q])=>{
     html += `<span class="badge ${st}">${st}: ${q}</span>`;
   });
   html += `</div><p class="mt">Tempo médio: ${(cycle.avg/3600000).toFixed(2)}h</p>`;
-  html += '<button id="op-csv" class="btn btn-primary mt">Exportar CSV</button>';
+  html += '<button id="op-csv" class="btn btn-primary mt"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 0v8"/><path d="M4 4l4 4 4-4"/><path d="M4 12h8v2H4z"/></svg>Exportar CSV</button>';
   area.innerHTML = html;
   document.getElementById('op-csv').addEventListener('click', () => {
     const rows = [['status','quantidade']];

--- a/public/styles.css
+++ b/public/styles.css
@@ -184,6 +184,7 @@ main#page-content{padding:var(--space-5);}
 .btn-danger{background:var(--danger);color:var(--primary-contrast);}
 .btn:hover{filter:brightness(.9);}
 .btn:focus-visible{box-shadow:0 0 0 3px var(--ring);}
+a:focus-visible{outline:none;box-shadow:0 0 0 3px var(--ring);}
 .btn:disabled{opacity:.6;cursor:not-allowed;}
 .btn.loading{pointer-events:none;opacity:.7;}
 .spinner{width:16px;height:16px;border:2px solid var(--primary-contrast);border-bottom-color:transparent;border-radius:50%;animation:spin 1s linear infinite;}
@@ -234,6 +235,7 @@ main#page-content{padding:var(--space-5);}
 .table th,.table td{border:1px solid var(--border);padding:var(--space-3);text-align:left;}
 .table.compact th,.table.compact td{padding:var(--space-2);}
 .table.listrada tbody tr:nth-child(odd){background:var(--neutral-50);}
+.table.sticky thead th{position:sticky;top:0;background:var(--card);z-index:1;}
 .progress{background:var(--border);height:8px;border-radius:4px;overflow:hidden;}
 .progress span{display:block;height:100%;background:var(--accent);}
 .empty-state{text-align:center;padding:var(--space-6) 0;color:var(--muted);}
@@ -243,6 +245,17 @@ main#page-content{padding:var(--space-5);}
 .input-icon input{padding-left:32px;}
 
 .card-actions{display:flex;gap:var(--space-2);margin-top:var(--space-3);}
+
+/* Agenda */
+.fc-event{border-radius:var(--radius-sm);border:none;padding:2px 4px;}
+.fc-event:hover{box-shadow:var(--shadow-sm);}
+.fc-event.novo{background:var(--info-bg);color:var(--info);}
+.fc-event.em_andamento{background:var(--warning-bg);color:var(--warning);}
+.fc-event.concluido{background:var(--success-bg);color:var(--success);}
+.fc-event.cancelado{background:var(--danger-bg);color:var(--danger);}
+
+/* Kanban */
+.kanban-card.dragging{box-shadow:var(--shadow-md);}
 
 /* Modal */
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;justify-content:center;align-items:center;z-index:1000;opacity:0;visibility:hidden;transition:opacity .2s,visibility .2s;}
@@ -255,9 +268,9 @@ main#page-content{padding:var(--space-5);}
 /* Auth specific */
 .auth-shell{min-height:100vh;display:grid;place-items:center;padding:var(--space-4);}
 .auth-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-md);box-shadow:var(--shadow-sm);padding:24px;width:100%;max-width:420px;}
-.tabs{display:flex;gap:.5rem;margin-bottom:1rem;}
-.tab-btn{flex:1;background:none;border:none;padding:.5rem;border-bottom:2px solid transparent;cursor:pointer;}
-.tab-btn[aria-selected="true"]{border-color:var(--primary);font-weight:600;}
+.tabs{display:flex;border-bottom:1px solid var(--border);margin-bottom:var(--space-4);}
+.tabs .tab{background:none;border:none;padding:var(--space-2) var(--space-4);cursor:pointer;border-bottom:2px solid transparent;}
+.tabs .tab.active{border-color:var(--accent);font-weight:600;}
 .tab-btn[aria-selected="false"]{color:var(--muted);}
 .tab-panel{display:none;}
 .tab-panel:not([hidden]){display:block;}
@@ -299,6 +312,7 @@ main#page-content{padding:var(--space-5);}
 .flex{display:flex;}
 .stack{display:flex;flex-direction:column;}
 .grid{display:grid;gap:var(--space-4);}
+.grid-2{display:grid;gap:var(--space-4);grid-template-columns:2fr 1fr;align-items:start;}
 .gap-sm{gap:var(--space-2);}
 .gap-md{gap:var(--space-4);}
 .gap-lg{gap:var(--space-6);}
@@ -317,4 +331,10 @@ main#page-content{padding:var(--space-5);}
 .muted{color:var(--muted);}
 .simple-table{width:100%;border-collapse:collapse;}
 .simple-table th,.simple-table td{padding:4px;border-bottom:1px solid var(--border);text-align:left;}
+
+@media print{
+  #topbar,#sidebar,#page-header,.no-print,.toast-stack{display:none!important;}
+  #page-content{margin:0;padding:0;}
+  .print-card{box-shadow:none;border:none;}
+}
 


### PR DESCRIPTION
## Summary
- add shared utilities for layout, tables, agenda events and printing
- align Orders, Agenda, Kanban and Reports views with new header, filters and summaries

## Testing
- `node --check public/js/views/ordersView.js`
- `node --check public/js/views/agendaView.js`
- `node --check public/js/views/kanbanView.js`
- `node --check public/js/views/reportsView.js`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689e59e9dd8c832e88611b2b48eeea6d