### PR TITLE
refine layout and theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,6 @@
                 <select id="unit-switcher" class="admin-only" style="display:none;"></select>
                 <button id="btnSignOut" class="link">Sair</button>
             </div>
-            <span id="net-status" class="offline-indicator" hidden>OFFLINE</span>
         </div>
     </header>
 

--- a/public/js/views/clientesView.js
+++ b/public/js/views/clientesView.js
@@ -28,10 +28,10 @@ export const renderClientesView = async (maybeId) => {
   });
 
   appContainer.innerHTML = `
-    <div class="card" style="max-width:640px;margin-bottom:var(--space-6);">
+    <div class="card container-md mb-lg">
       <div id="clientes-alert" class="alert" aria-live="polite"></div>
-      <form id="form-new-customer" class="grid" aria-busy="false" style="grid-template-columns:1fr 1fr;">
-        <div class="form-row" style="grid-column:1/3;">
+      <form id="form-new-customer" class="form-grid" aria-busy="false">
+        <div class="form-row full">
           <label for="cName">Nome*</label>
           <input id="cName" class="input" type="text" required />
         </div>
@@ -43,15 +43,15 @@ export const renderClientesView = async (maybeId) => {
           <label for="cEmail">Email</label>
           <input id="cEmail" class="input" type="email" />
         </div>
-        <div class="form-row" style="grid-column:1/3;display:flex;justify-content:space-between;">
-          <button type="reset" class="btn">Limpar</button>
+        <div class="form-row actions full">
+          <button type="reset" class="btn btn-ghost">Limpar</button>
           <button class="btn btn-primary">Adicionar</button>
         </div>
       </form>
     </div>
 
-    <div class="card" style="max-width:640px;margin-bottom:var(--space-6);">
-      <div class="form-row">
+    <div class="card container-md mb-lg">
+      <div class="flex gap-sm">
         <div class="input-icon" style="flex:1;">
           <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707 1.414-1.414-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z"/>
@@ -66,12 +66,12 @@ export const renderClientesView = async (maybeId) => {
     </div>
 
     <div class="card">
-      <table class="table compact listrada">
-        <thead style="position:sticky;top:0;background:var(--card);"><tr><th>Nome</th><th>Telefone</th><th>Email</th><th>Ações</th></tr></thead>
+      <table class="table compact listrada sticky">
+        <thead><tr><th>Nome</th><th>Telefone</th><th>Email</th><th>Ações</th></tr></thead>
         <tbody id="customers-list"></tbody>
       </table>
     </div>
-    <button class="btn btn-secondary" id="load-more" hidden style="margin:var(--space-4) auto 0;">Carregar mais</button>
+    <button class="btn btn-secondary mt-md mx-auto" id="load-more" hidden>Carregar mais</button>
   `;
 
   document.getElementById('form-new-customer').onsubmit = onAddCustomer;
@@ -136,7 +136,7 @@ function renderCustomerList() {
   }
 
   if (!list.length) {
-    container.innerHTML = `<tr><td colspan="4"><div class="empty-state"><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zM2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12zm11 5v-2h-2v2h2zm0-4V7h-2v6h2z"/></svg><p>Nenhum cliente encontrado</p><button id="empty-add" class="btn btn-primary">Adicionar cliente</button></div></td></tr>`;
+    container.innerHTML = `<tr><td colspan="4"><div class="empty-state"><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zM2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12zm11 5v-2h-2v2h2zm0-4V7h-2v6h2z"/></svg><p>Nenhum cliente encontrado.</p><button id="empty-add" class="btn btn-primary">Adicionar</button></div></td></tr>`;
     document.getElementById('empty-add').onclick = () => document.getElementById('cName').focus();
     return;
   }
@@ -250,7 +250,7 @@ async function renderCustomerDetail(customerId) {
       <div id="clientes-alert" class="alert" aria-live="polite"></div>
 
       <h3 class="mt">Veículos</h3>
-      <form id="form-vehicle" class="stack mt" aria-busy="false" style="max-width:480px;">
+      <form id="form-vehicle" class="form-grid mt" aria-busy="false" style="max-width:480px;">
         <div class="form-row">
           <label for="vPlate">Placa</label>
           <input id="vPlate" class="input" required />
@@ -259,7 +259,7 @@ async function renderCustomerDetail(customerId) {
           <label for="vModel">Modelo</label>
           <input id="vModel" class="input" required />
         </div>
-        <div class="form-row" style="justify-content:flex-end;">
+        <div class="form-row actions full">
           <button class="btn btn-primary">Adicionar veículo</button>
         </div>
       </form>

--- a/public/js/views/servicosView.js
+++ b/public/js/views/servicosView.js
@@ -13,10 +13,10 @@ export const renderServicosView = async () => {
     actions: [{ id: 'header-new-servico', label: 'Novo serviço' }]
   });
   appContainer.innerHTML = `
-    <div class="card" style="max-width:520px;margin-bottom:var(--space-6);">
+    <div class="card container-sm mb-lg">
       <div id="s-alert" class="alert" aria-live="polite"></div>
-      <form id="form-servico" class="stack" aria-busy="false">
-        <div class="form-row">
+      <form id="form-servico" class="form-grid" aria-busy="false">
+        <div class="form-row full">
           <label for="sName">Nome*</label>
           <input id="sName" class="input" required />
         </div>
@@ -24,13 +24,14 @@ export const renderServicosView = async () => {
           <label for="sPrice">Preço*</label>
           <input id="sPrice" class="input" type="number" min="0" step="0.01" required />
         </div>
-        <div class="form-row" style="justify-content:flex-end;">
+        <div class="form-row actions full">
+          <button type="reset" class="btn btn-ghost">Limpar</button>
           <button class="btn btn-primary">Adicionar</button>
         </div>
       </form>
     </div>
 
-    <div class="card" style="max-width:520px;margin-bottom:var(--space-6);">
+    <div class="card container-sm mb-lg">
       <div class="input-icon">
         <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707 1.414-1.414-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z"/>
@@ -40,7 +41,7 @@ export const renderServicosView = async () => {
     </div>
 
     <div class="card">
-      <table class="table compact listrada">
+      <table class="table compact listrada sticky">
         <thead><tr><th>Nome</th><th>Preço</th><th></th></tr></thead>
         <tbody id="servicos-list"></tbody>
       </table>
@@ -81,7 +82,7 @@ function renderList() {
   const body = document.getElementById('servicos-list');
   const filtered = term ? servicos.filter(s => (s.name||'').toLowerCase().includes(term)) : servicos;
   if (!filtered.length) {
-    body.innerHTML = `<tr><td colspan="3"><div class="empty-state"><svg viewBox='0 0 24 24' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a10 10 0 100 20 10 10 0 000-20zM2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12zm11 5v-2h-2v2h2zm0-4V7h-2v6h2z'/></svg><p>Nenhum serviço.</p><button id='empty-servico' class='btn btn-primary'>Adicionar serviço</button></div></td></tr>`;
+    body.innerHTML = `<tr><td colspan="3"><div class="empty-state"><svg viewBox='0 0 24 24' fill='currentColor' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a10 10 0 100 20 10 10 0 000-20zM2 12C2 6.48 6.48 2 12 2s10 4.48 10 10-4.48 10-10 10S2 17.52 2 12zm11 5v-2h-2v2h2zm0-4V7h-2v6h2z'/></svg><p>Nenhum serviço encontrado.</p><button id='empty-servico' class='btn btn-primary'>Adicionar</button></div></td></tr>`;
     document.getElementById('empty-servico').onclick = () => document.getElementById('sName').focus();
     return;
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,34 +1,31 @@
 /* --- DESIGN TOKENS --- */
 :root {
   /* base colors */
-  --neutral-0:#FFFFFF;
-  --neutral-50:#F7F8FB;
-  --neutral-100:#EFF1F5;
-  --neutral-200:#E6E8F0;
-  --neutral-900:#0F172A;
-
   --bg:#F7F8FB;
   --card:#FFFFFF;
   --border:#E6E8F0;
-  --fg:#0F172A;
+  --text:#0F172A;
   --muted:#6B7280;
   --accent:#2563EB;
+
+  /* status */
   --info:#3B82F6;
   --warning:#F59E0B;
   --success:#10B981;
   --danger:#EF4444;
-  --info-bg:#DBEAFE;
-  --warning-bg:#FEF3C7;
-  --success-bg:#D1FAE5;
-  --danger-bg:#FEE2E2;
 
-  --primary:var(--fg);
+  --info-bg:rgba(59,130,246,.15);
+  --warning-bg:rgba(245,158,11,.15);
+  --success-bg:rgba(16,185,129,.15);
+  --danger-bg:rgba(239,68,68,.15);
+
+  --primary:var(--text);
   --primary-contrast:#FFFFFF;
   --ring:rgba(37,99,235,.3);
 
   /* radii */
-  --radius-sm:8px; /* inputs/buttons */
   --radius-md:12px; /* cards */
+  --radius-sm:8px; /* inputs/buttons */
 
   /* shadow */
   --shadow-sm:0 1px 2px rgba(16,24,40,.06);
@@ -56,6 +53,16 @@
   --topbar-h:56px;
   --sidebar-w:248px;
   --sidebar-collapsed:72px;
+}
+
+[data-theme="dark"] {
+  --bg:#0B1220;
+  --card:#111827;
+  --border:#1F2937;
+  --text:#E7EAF3;
+  --muted:#9CA3AF;
+  --accent:#3B82F6;
+  --ring:rgba(59,130,246,.3);
 }
 
 /* --- RESET --- */
@@ -87,7 +94,7 @@ label{font-size:var(--font-12);font-weight:600;text-transform:uppercase;letter-s
   z-index:100;
 }
 #topbar .brand{color:var(--accent);font-weight:600;}
-#topbar input[type="search"]{flex:1;max-width:400px;}
+#topbar input[type="search"]{flex:1;max-width:520px;}
 
 #sidebar{
   position:fixed;
@@ -154,7 +161,7 @@ label{font-size:var(--font-12);font-weight:600;text-transform:uppercase;letter-s
 .menu.hidden{display:none;}
 .menu a,.menu button{background:none;border:none;text-align:left;padding:var(--space-2) var(--space-3);cursor:pointer;color:var(--primary);text-decoration:none;}
 .skeleton{
-  background:var(--neutral-200);
+  background:var(--border);
   height:1rem;
   animation:pulse 1.5s infinite;
 }
@@ -230,15 +237,24 @@ a:focus-visible{outline:none;box-shadow:0 0 0 3px var(--ring);}
   box-shadow:0 0 0 3px var(--ring);
 }
 
-.form-row{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-bottom:var(--space-3);}
+.input::placeholder,textarea::placeholder{color:var(--muted);}
+.input:disabled,select:disabled,textarea:disabled{opacity:.6;cursor:not-allowed;}
+
+.form-grid{display:grid;gap:var(--space-3);grid-template-columns:1fr 1fr;}
+.form-grid .full{grid-column:1/3;}
+@media(max-width:640px){.form-grid{grid-template-columns:1fr;}}
+
+.form-row{display:flex;flex-direction:column;gap:4px;margin-bottom:var(--space-3);}
+.form-row.actions{flex-direction:row;justify-content:flex-end;gap:var(--space-2);margin-top:var(--space-2);}
 .table{width:100%;border-collapse:collapse;margin-top:var(--space-4);}
+.table tr{height:44px;}
 .table th,.table td{border:1px solid var(--border);padding:var(--space-3);text-align:left;}
 .table.compact th,.table.compact td{padding:var(--space-2);}
-.table.listrada tbody tr:nth-child(odd){background:var(--neutral-50);}
+.table.listrada tbody tr:nth-child(odd){background:var(--bg);}
 .table.sticky thead th{position:sticky;top:0;background:var(--card);z-index:1;}
 .progress{background:var(--border);height:8px;border-radius:4px;overflow:hidden;}
 .progress span{display:block;height:100%;background:var(--accent);}
-.empty-state{text-align:center;padding:var(--space-6) 0;color:var(--muted);}
+.empty-state{text-align:center;padding:var(--space-6) 0;color:var(--muted);display:flex;flex-direction:column;gap:var(--space-3);align-items:center;}
 
 .input-icon{position:relative;}
 .input-icon svg{position:absolute;left:8px;top:50%;transform:translateY(-50%);width:16px;height:16px;color:var(--muted);}
@@ -294,7 +310,7 @@ a:focus-visible{outline:none;box-shadow:0 0 0 3px var(--ring);}
 #signCanvas{width:100%;max-width:400px;}
 .public-quote{max-width:600px;margin:auto;}
 .photo-drop{border:2px dashed var(--border);padding:var(--space-4);text-align:center;}
-.photo-drop.drag{background:var(--neutral-100);}
+.photo-drop.drag{background:var(--bg);}
 .photo-grid{display:flex;flex-wrap:wrap;gap:var(--space-2);}
 .photo-grid figure{width:120px;margin:0;}
 .photo-grid img{width:100%;height:90px;object-fit:cover;}
@@ -313,9 +329,14 @@ a:focus-visible{outline:none;box-shadow:0 0 0 3px var(--ring);}
 .stack{display:flex;flex-direction:column;}
 .grid{display:grid;gap:var(--space-4);}
 .grid-2{display:grid;gap:var(--space-4);grid-template-columns:2fr 1fr;align-items:start;}
-.gap-sm{gap:var(--space-2);}
+.container-sm{max-width:520px;margin:0 auto;}
+.container-md{max-width:640px;margin:0 auto;}
+.mx-auto{margin-left:auto;margin-right:auto;}
+.mb-lg{margin-bottom:var(--space-5);}
+.ring{box-shadow:0 0 0 3px var(--ring);}
+.gap-sm{gap:var(--space-3);}
 .gap-md{gap:var(--space-4);}
-.gap-lg{gap:var(--space-6);}
+.gap-lg{gap:var(--space-5);}
 .mt-sm{margin-top:var(--space-2);}
 .mt-md{margin-top:var(--space-4);}
 .mt-lg{margin-top:var(--space-6);}


### PR DESCRIPTION
## Summary
- implement light/dark design tokens and layout utilities
- streamline topbar and forms for customers and services
- tweak tables, empty states and component styling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e5fa2130c832ea6cdd4757e75ad34