### PR TITLE
Add mobile shell with tab bar and FAB

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,12 +2,13 @@
 <html lang="pt-br" data-theme="light">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Gestão Estética Automotiva</title>
     <meta name="theme-color" content="#F7F8FB">
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="icon" type="image/svg+xml" href="/icon.svg">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/mobile.css?v=m1">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.min.css">
 </head>
 <body>
@@ -66,6 +67,27 @@
 
     <section id="page-header" class="page-header hidden"></section>
     <main id="page-content" class="main"></main>
+    <nav id="tabbar" class="tabbar">
+        <a href="#dashboard" data-route="#dashboard">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2h-4v-6H9v6H5a2 2 0 0 1-2-2z"/></svg>
+            <span>Dashboard</span>
+        </a>
+        <a href="#agenda" data-route="#agenda">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            <span>Agenda</span>
+        </a>
+        <a href="#orders" data-route="#orders">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><circle cx="4" cy="6" r="1"/><circle cx="4" cy="12" r="1"/><circle cx="4" cy="18" r="1"/></svg>
+            <span>Ordens</span>
+        </a>
+        <a href="#clientes" data-route="#clientes">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+            <span>Clientes</span>
+        </a>
+    </nav>
+    <button id="fab-new" class="fab" aria-label="Nova OS" onclick="location.hash='#orders/new'">
+        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+    </button>
 
     <div class="auth-shell hidden">
         <div class="auth-card">

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -21,6 +21,9 @@ const appContainer = document.getElementById('page-content');
 const pageHeader = document.getElementById('page-header');
 const netStatus = document.getElementById('net-status');
 const sidebarLinks = document.querySelectorAll('#sidebar a[data-route]');
+const tabbarLinks = document.querySelectorAll('#tabbar a[data-route]');
+const tabbar = document.getElementById('tabbar');
+const fabNew = document.getElementById('fab-new');
 const globalSearch = document.getElementById('global-search');
 
 window.setPageHeader = ({ title = '', breadcrumbs = [], actions = [], filters = '' }) => {
@@ -86,6 +89,14 @@ export function navigate() {
   pageHeader.style.display = 'none';
   pageHeader.innerHTML = '';
 
+  if (hash === '#login') {
+    tabbar?.style.setProperty('display', 'none');
+    fabNew?.style.setProperty('display', 'none');
+  } else {
+    tabbar?.style.removeProperty('display');
+    fabNew?.style.removeProperty('display');
+  }
+
   if (!auth.currentUser && hash !== '#login' && !hash.startsWith('#q/')) {
     location.hash = '#login';
     return;
@@ -113,8 +124,11 @@ export function navigate() {
   }
 
   sidebarLinks.forEach(link => link.classList.remove('active'));
+  tabbarLinks.forEach(link => link.classList.remove('active'));
   const activeLink = document.querySelector(`#sidebar a[data-route="${mainPath}"]`);
   activeLink?.classList.add('active');
+  const activeTab = document.querySelector(`#tabbar a[data-route="${mainPath}"]`);
+  activeTab?.classList.add('active');
 
   const fn = routes[mainPath];
   if (typeof fn === 'function') {

--- a/public/mobile.css
+++ b/public/mobile.css
@@ -1,0 +1,145 @@
+:root {
+  --bg:#F9FAFB;
+  --card:#FFFFFF;
+  --line:#ECEFF3;
+  --text:#0F172A;
+  --muted:#6B7280;
+  --accent:#22C55E;
+  --accent-weak:#D1FADF;
+  --info:#3B82F6;
+  --warning:#F59E0B;
+  --success:#10B981;
+  --danger:#EF4444;
+  --radius-card:16px;
+  --radius-btn:12px;
+  --radius-primary:24px;
+  --shadow:0 6px 20px rgba(16,24,40,.06);
+  font-size:16px;
+}
+[data-theme="dark"] {
+  --bg:#0B1220;
+  --card:#121826;
+  --line:#1F2937;
+  --text:#E7EAF3;
+  --muted:#9CA3AF;
+  --accent:#32D74B;
+  --accent-weak:#11381B;
+}
+body {
+  margin:0;
+  font-family:system-ui, sans-serif;
+  background:var(--bg);
+  color:var(--text);
+}
+main.main {
+  padding:16px;
+  padding-bottom:100px;
+  max-width:430px;
+  margin:0 auto;
+}
+.card {
+  background:var(--card);
+  border-radius:var(--radius-card);
+  padding:16px;
+  box-shadow:var(--shadow);
+  margin-bottom:16px;
+}
+.btn {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  height:44px;
+  padding:0 16px;
+  font-size:15px;
+  font-weight:600;
+  border-radius:var(--radius-btn);
+  border:1px solid transparent;
+  cursor:pointer;
+  transition:opacity .15s, transform .15s;
+}
+.btn:active {
+  transform:scale(.98);
+}
+.btn-primary {
+  background:var(--accent);
+  color:#fff;
+  border-radius:var(--radius-primary);
+}
+.btn-secondary {
+  background:var(--card);
+  border:1px solid var(--line);
+}
+.btn-ghost {
+  background:transparent;
+}
+.btn-danger {
+  background:var(--danger);
+  color:#fff;
+  border-radius:var(--radius-primary);
+}
+.input {
+  width:100%;
+  height:44px;
+  padding:0 12px;
+  border:1px solid var(--line);
+  border-radius:var(--radius-btn);
+  background:var(--card);
+  color:var(--text);
+}
+.input:focus {
+  outline:3px solid var(--accent);
+}
+.tabbar {
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  height:64px;
+  background:var(--card);
+  border-top:1px solid var(--line);
+  display:flex;
+  justify-content:space-around;
+  align-items:center;
+  z-index:100;
+}
+.tabbar a {
+  flex:1;
+  text-decoration:none;
+  color:var(--muted);
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  font-size:11px;
+  gap:2px;
+}
+.tabbar a.active {
+  color:var(--accent);
+}
+.fab {
+  position:fixed;
+  bottom:80px;
+  left:50%;
+  transform:translateX(-50%);
+  width:56px;
+  height:56px;
+  border-radius:50%;
+  border:none;
+  background:var(--accent);
+  color:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  box-shadow:var(--shadow);
+  z-index:110;
+}
+#topbar,
+#sidebar {
+  display:none;
+}
+@media (min-width:768px) {
+  #tabbar,
+  .fab { display:none; }
+  #topbar { display:flex; }
+  #sidebar { display:block; }
+  main.main { padding-bottom:0; max-width:720px; }
+}


### PR DESCRIPTION
## Summary
- add Mint Mobile theme stylesheet with tokens and responsive components
- wire up mobile tab bar and floating action button
- update router to highlight active tab and hide mobile chrome on login

## Testing
- `npm test --prefix functions` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e68a726bc832e9fa733f1e3caaef3