### PR TITLE
fix agenda, dashboard and orders layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,9 +7,11 @@
     <meta name="theme-color" content="#F7F8FB">
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="icon" type="image/svg+xml" href="/icon.svg">
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="/mobile.css?v=m1">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.min.css">
+    <link rel="stylesheet" href="styles.css?v=fix-agenda1">
+    <link rel="stylesheet" href="/mobile.css?v=fix-agenda1">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/index.global.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.11/index.global.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@6.1.11/index.global.min.css">
 </head>
 <body>
     <header id="topbar" class="topbar hidden">
@@ -66,7 +68,7 @@
     </aside>
 
     <section id="page-header" class="page-header hidden"></section>
-    <main id="page-content" class="main"></main>
+    <main id="page-content" class="container"></main>
     <nav id="tabbar" class="tabbar">
         <a href="#dashboard" data-route="#dashboard">
             <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2h-4v-6H9v6H5a2 2 0 0 1-2-2z"/></svg>
@@ -162,10 +164,14 @@
 
     <div id="modal-placeholder"></div>
 
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.11/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@6.1.11/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@6.1.11/index.global.min.js"></script>
+
     <script type="module" src="js/auth.js"></script>
     <script type="module" src="js/main.js"></script>
     <script type="module" src="js/messaging.js"></script>
-    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
     <script>
       if('serviceWorker' in navigator){
         navigator.serviceWorker.register('/service-worker.js');

--- a/public/js/views/ordersView.js
+++ b/public/js/views/ordersView.js
@@ -52,8 +52,8 @@ async function renderOrdersList() {
   });
   appContainer.innerHTML = `
     <section class="card container-lg">
-      <table class="table compact listrada sticky mt">
-        <thead><tr><th>Cliente</th><th>Status</th><th>Total</th><th>Agendado</th><th>Criado</th><th></th></tr></thead>
+      <table class="table table--compact table--striped mt">
+        <thead><tr><th>Cliente</th><th>Status</th><th>Total</th><th>Agendado</th><th>Criado</th><th style="min-width:80px">Ações</th></tr></thead>
         <tbody id="orders-body"></tbody>
       </table>
     </section>

--- a/public/mobile.css
+++ b/public/mobile.css
@@ -143,3 +143,64 @@ main.main {
   #sidebar { display:block; }
   main.main { padding-bottom:0; max-width:720px; }
 }
+
+#page-content.container {
+  padding:16px;
+  padding-bottom:100px;
+  max-width:430px;
+  margin:0 auto;
+}
+@media (min-width:768px) {
+  #page-content.container { padding-bottom:0; max-width:720px; }
+}
+
+#page-content table {
+  width:100%;
+  font-size:14px;
+  line-height:44px;
+  border-collapse:separate;
+  border-spacing:0;
+}
+#page-content table th {
+  background:var(--card);
+  border-bottom:1px solid var(--line);
+  position:sticky;
+  top:0;
+  z-index:1;
+}
+#page-content table td,
+#page-content table th {
+  padding:12px 16px;
+}
+#page-content table.table--compact td,
+#page-content table.table--compact th {
+  padding:8px 12px;
+}
+#page-content table.table--striped tbody tr:nth-child(even) {
+  background:rgba(0,0,0,.02);
+}
+
+.cell {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  height:56px;
+  padding:0 16px;
+  border-bottom:1px solid var(--line);
+}
+.cell__left { display:flex; flex-direction:column; }
+.cell__title { font-size:16px; font-weight:600; }
+.cell__desc { font-size:12px; color:var(--muted); }
+.cell__right { display:flex; flex-direction:column; align-items:flex-end; }
+.cell__value { font-weight:600; }
+
+.kpi-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:16px; }
+.kpi-card { background:var(--card); padding:16px; border-radius:var(--radius-card); box-shadow:var(--shadow); display:flex; flex-direction:column; }
+.kpi-title { font-size:12px; color:var(--muted); }
+.kpi-value { font-size:20px; font-weight:600; }
+
+.badge { display:inline-block; padding:2px 8px; border-radius:9999px; font-size:12px; background:var(--line); color:var(--text); }
+.badge--info { background:var(--info); color:#fff; }
+.badge--warning { background:var(--warning); color:#fff; }
+.badge--success { background:var(--success); color:#fff; }
+.badge--danger { background:var(--danger); color:#fff; }


### PR DESCRIPTION
## Summary
- load FullCalendar globals via CDN and use correct constructor
- render dashboard and agenda inside #page-content and add basic KPI placeholders
- style orders table with compact/striped classes and add compatibility CSS

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e6d2e1f1c832e9545b1492c4134f3