### PR TITLE
Refine mobile dashboard and agenda experience

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -165,6 +165,7 @@
     <div id="modal-placeholder"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/locales/pt-br.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.11/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@6.1.11/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@6.1.11/index.global.min.js"></script>

--- a/public/js/views/agendaView.js
+++ b/public/js/views/agendaView.js
@@ -49,6 +49,10 @@ export const renderAgendaView = async () => {
   if (!FC || !FC.Calendar) throw new Error('FullCalendar não carregado — verifique CDNs e ordem dos scripts.');
   calendar = new FC.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
+    locale: 'pt-br',
+    headerToolbar: { left: 'title', right: 'today prev,next dayGridMonth,timeGridDay' },
+    buttonText: { today: 'Hoje', month: 'Mês', day: 'Dia' },
+    navLinks: true,
     selectable: true,
     height: 'auto',
     events,
@@ -108,41 +112,42 @@ async function openNewModal(start=null, end=null) {
   const clients = await getCustomers();
   const servicos = await getServicos();
   modalPlaceholder.innerHTML = `
-    <div class="modal"><div class="card">
-      <div class="card-header">Novo agendamento</div>
-      <div class="card-body">
-        <form id="agenda-form" class="grid">
-          <label>Cliente*
-            <select id="aCustomer" required>
-              <option value="">—</option>
-              ${clients.map(c=>`<option value="${c.id}">${esc(c.name||'-')}</option>`).join('')}
-            </select>
-          </label>
-          <label>Veículo*
-            <select id="aVehicle" required><option value="">—</option></select>
-          </label>
-          <label>Serviço*
-            <select id="aService" required>
-              <option value="">—</option>
-              ${servicos.map(s=>`<option value="${s.id}" data-name="${attr(s.name)}" data-price="${Number(s.price)||0}">${esc(s.name)}</option>`).join('')}
-            </select>
-          </label>
-          <label>Início* <input id="aStart" type="datetime-local" required value="${start?toLocal(start):''}" /></label>
-          <label>Fim <input id="aEnd" type="datetime-local" value="${end?toLocal(end):''}" /></label>
-          <label>Notas <textarea id="aNotes"></textarea></label>
-          <div class="card-actions">
-            <button class="btn">Criar</button>
-            <button type="button" class="link" id="aCancel">Cancelar</button>
-          </div>
-        </form>
-      </div>
-    </div></div>
+    <div class="sheet-overlay" id="aOverlay"></div>
+    <div class="sheet" id="agendaSheet">
+      <div class="sheet-handle"></div>
+      <h2 class="sheet-title">Novo agendamento</h2>
+      <form id="agenda-form" class="grid">
+        <label>Cliente*
+          <select id="aCustomer" required>
+            <option value="">—</option>
+            ${clients.map(c=>`<option value="${c.id}">${esc(c.name||'-')}</option>`).join('')}
+          </select>
+        </label>
+        <label>Veículo*
+          <select id="aVehicle" required><option value="">—</option></select>
+        </label>
+        <label>Serviço*
+          <select id="aService" required>
+            <option value="">—</option>
+            ${servicos.map(s=>`<option value="${s.id}" data-name="${attr(s.name)}" data-price="${Number(s.price)||0}">${esc(s.name)}</option>`).join('')}
+          </select>
+        </label>
+        <label>Início* <input id="aStart" type="datetime-local" required value="${start?toLocal(start):''}" /></label>
+        <label>Fim <input id="aEnd" type="datetime-local" value="${end?toLocal(end):''}" /></label>
+        <label>Notas <textarea id="aNotes"></textarea></label>
+        <div class="sheet-actions">
+          <button type="button" class="btn btn-ghost" id="aCancel">Cancelar</button>
+          <button class="btn btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
   `;
   document.getElementById('aCustomer').onchange = async e => {
     const vs = await getVehiclesForCustomer(e.target.value);
     document.getElementById('aVehicle').innerHTML =
       '<option value="">—</option>' + vs.map(v=>`<option value="${v.id}">${esc(v.model||v.plate||'-')}</option>`).join('');
   };
+  document.getElementById("aOverlay").onclick = closeModal;
   document.getElementById('aCancel').onclick = closeModal;
   document.getElementById('agenda-form').onsubmit = async e => {
     e.preventDefault();

--- a/public/js/views/dashboardView.js
+++ b/public/js/views/dashboardView.js
@@ -13,17 +13,19 @@ export async function renderDashboardView() {
   const root = document.getElementById('page-content');
   if (!root) throw new Error('#page-content não encontrado');
   root.innerHTML = `
-  <section class="mobile container">
-    <header class="page-header">
-      <h1>Dashboard</h1>
-    </header>
-    <div class="kpi-grid">
-      <div class="kpi-card"><span class="kpi-title">OS Abertas</span><span class="kpi-value">--</span></div>
-      <div class="kpi-card"><span class="kpi-title">Hoje</span><span class="kpi-value">--</span></div>
-      <div class="kpi-card"><span class="kpi-title">Faturamento</span><span class="kpi-value">--</span></div>
-      <div class="kpi-card"><span class="kpi-title">Clientes</span><span class="kpi-value">--</span></div>
-    </div>
-    <div id="dash-recent"></div>
+  <header class="page-header">
+    <h1 class="page-title">Dashboard</h1>
+    <p class="page-subtitle muted"></p>
+  </header>
+  <section class="kpi-grid">
+    <div class="kpi-card"><span class="kpi-title">OS Abertas</span><span class="kpi-value">--</span></div>
+    <div class="kpi-card"><span class="kpi-title">Hoje</span><span class="kpi-value">--</span></div>
+    <div class="kpi-card"><span class="kpi-title">Faturamento</span><span class="kpi-value">--</span></div>
+    <div class="kpi-card"><span class="kpi-title">Clientes</span><span class="kpi-value">--</span></div>
+  </section>
+  <section>
+    <h2 class="section-title">Hoje</h2>
+    <div id="dash-today" class="card"></div>
   </section>`;
 
   try {
@@ -43,7 +45,7 @@ export async function renderDashboardView() {
     kpis[3].textContent = clients;
 
     const recent = await getNextSchedules(5);
-    const dashRecent = document.getElementById('dash-recent');
+    const dashToday = document.getElementById('dash-today');
     if (recent.length) {
       const items = [];
       for (const o of recent) {
@@ -52,9 +54,9 @@ export async function renderDashboardView() {
         }
         items.push(`<div><a href="#orders/${o.id}">${esc(customerCache[o.customerId])} - ${esc(o.vehicleId)} - ${formatDate(o.scheduledStart)}</a></div>`);
       }
-      dashRecent.innerHTML = items.join('');
+      dashToday.innerHTML = items.join('');
     } else {
-      dashRecent.innerHTML = '<p class="muted">Nenhum agendamento</p>';
+      dashToday.innerHTML = '<p class="muted"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg> Nada hoje</p>'
     }
   } catch (e) {
     console.error(e);

--- a/public/mobile.css
+++ b/public/mobile.css
@@ -204,3 +204,15 @@ main.main {
 .badge--warning { background:var(--warning); color:#fff; }
 .badge--success { background:var(--success); color:#fff; }
 .badge--danger { background:var(--danger); color:#fff; }
+.page-header{margin-bottom:16px;}
+.page-title{font-size:22px;font-weight:600;margin:0;}
+.page-subtitle{margin:4px 0 0;font-size:14px;color:var(--muted);}
+.section-title{font-size:16px;font-weight:600;margin:0 0 8px;}
+.muted{color:var(--muted);}
+.cell__right{display:flex;flex-direction:column;align-items:flex-end;gap:4px;}
+.cell svg.chevron{width:16px;height:16px;color:var(--muted);margin-left:8px;}
+.sheet-overlay{position:fixed;inset:0;background:rgba(0,0,0,.3);backdrop-filter:blur(2px);z-index:90;}
+.sheet{position:fixed;left:0;right:0;bottom:0;background:var(--card);border-top-left-radius:16px;border-top-right-radius:16px;padding:16px;box-shadow:0 -4px 16px rgba(0,0,0,.1);z-index:100;animation:sheetUp .2s ease-out;}
+.sheet-handle{width:40px;height:4px;background:var(--line);border-radius:2px;margin:0 auto 12px;}
+.sheet-actions{display:flex;justify-content:space-between;margin-top:16px;}
+@keyframes sheetUp{from{transform:translateY(100%);}to{transform:translateY(0);}}


### PR DESCRIPTION
## Summary
- localize FullCalendar to pt-BR and simplify agenda toolbar
- redesign dashboard header and today's section
- list orders as mobile-friendly cells with badges and chevron
- add bottom sheet styling and supporting mobile CSS tweaks

## Testing
- `npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e82292e24832eb0ff7e31dd577a26