### PR TITLE
Fix syntax error in orders view

### DIFF
--- a/public/js/views/ordersView.js
+++ b/public/js/views/ordersView.js
@@ -49,7 +49,8 @@ async function renderOrdersList() {
         <input type="date" id="filter-to" />
         <button class="btn" id="applyFilters">Filtrar</button>
       </div>`
-    appContainer.innerHTML = `
+  });
+  appContainer.innerHTML = `
       <div id="orders-list"></div>
     `;
 


### PR DESCRIPTION
## Summary
- close `window.setPageHeader` call properly in orders view to avoid runtime syntax error

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8500953c832e9e853c726461ea08