### PR TITLE
fix: restore renderOrderDetail definition

### DIFF
--- a/public/js/views/ordersView.js
+++ b/public/js/views/ordersView.js
@@ -101,6 +101,13 @@ function renderOrdersTable(list) {
     }
   };
 }
+async function renderOrderDetail(orderId) {
+  const isNew = !orderId;
+  let order = isNew ? null : await getOrderById(orderId);
+  const clients = await getCustomers();
+  const servicos = await getServicos();
+  let vehicles = [];
+  if (order?.customerId) {
     vehicles = await getVehiclesForCustomer(order.customerId);
   }
   let users = [];


### PR DESCRIPTION
## Summary
- restore missing renderOrderDetail function in orders view

## Testing
- `node --check public/js/views/ordersView.js`
- `cd functions && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e87c97758832e9b33c798060001d8