### PR TITLE
fix: show login by default to avoid blank screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -91,7 +91,7 @@
         <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
     </button>
 
-    <div class="auth-shell hidden">
+    <div class="auth-shell">
         <div class="auth-card">
             <div class="tabs">
                 <button id="tab-signin" class="tab-btn" role="tab" aria-selected="true" data-target="#tab-login" aria-controls="tab-login">Entrar</button>


### PR DESCRIPTION
## Summary
- ensure login shell is visible by default

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8aa32954832e934b8eca0bc23573