### PR TITLE
feat: mobile agenda and UI refinements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -165,10 +165,10 @@
     <div id="modal-placeholder"></div>
 
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/index.global.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/locales/pt-br.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@6.1.11/index.global.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@6.1.11/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@6.1.11/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@6.1.11/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@6.1.11/locales/pt-br.global.min.js"></script>
 
     <script type="module" src="js/auth.js"></script>
     <script type="module" src="js/main.js"></script>

--- a/public/js/views/agendaView.js
+++ b/public/js/views/agendaView.js
@@ -10,6 +10,10 @@ export const renderAgendaView = async () => {
     title: 'Agenda',
     breadcrumbs: ['Operação', 'Agenda'],
     filters: `
+      <div class="segmented" id="agView">
+        <button class="segmented__item segmented__item--active" data-view="dayGridMonth">Mês</button>
+        <button class="segmented__item" data-view="timeGridDay">Dia</button>
+      </div>
       <div class="grid">
         <input id="searchAgenda" placeholder="Cliente ou placa" />
         <input type="date" id="agFrom" />
@@ -21,6 +25,7 @@ export const renderAgendaView = async () => {
   const calendarEl = document.getElementById('calendar');
 
   let events = [];
+  const orderMap = {};
   try {
     const orders = await getOrders();
     const customers = {};
@@ -33,14 +38,17 @@ export const renderAgendaView = async () => {
         vehicles[o.vehicleId] = (await getVehicleById(o.vehicleId))?.plate || '';
       }
     }
-    events = orders.filter(o=>o.scheduledStart).map(o => ({
-      id: o.id,
-      title: `${customers[o.customerId] || ''} - ${vehicles[o.vehicleId] || ''}`,
-      start: o.scheduledStart.seconds ? new Date(o.scheduledStart.seconds*1000) : o.scheduledStart,
-      end: o.scheduledEnd?.seconds ? new Date(o.scheduledEnd.seconds*1000) : (o.scheduledEnd || null),
-      classNames: [o.status],
-      extendedProps: { customerId: o.customerId, vehicleId: o.vehicleId, customerName: customers[o.customerId]||'', plate: vehicles[o.vehicleId]||'' }
-    }));
+    events = orders.filter(o=>o.scheduledStart).map(o => {
+      orderMap[o.id] = o;
+      return {
+        id: o.id,
+        title: `${customers[o.customerId] || ''} - ${vehicles[o.vehicleId] || ''}`,
+        start: o.scheduledStart.seconds ? new Date(o.scheduledStart.seconds*1000) : o.scheduledStart,
+        end: o.scheduledEnd?.seconds ? new Date(o.scheduledEnd.seconds*1000) : (o.scheduledEnd || null),
+        classNames: [o.status],
+        extendedProps: { customerId: o.customerId, vehicleId: o.vehicleId, customerName: customers[o.customerId]||'', plate: vehicles[o.vehicleId]||'' }
+      };
+    });
   } catch(err) {
     console.error(err);
   }
@@ -50,16 +58,20 @@ export const renderAgendaView = async () => {
   calendar = new FC.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     locale: 'pt-br',
-    headerToolbar: { left: 'title', right: 'today prev,next dayGridMonth,timeGridDay' },
+    headerToolbar: { left: 'title', right: 'today prev,next' },
     buttonText: { today: 'Hoje', month: 'Mês', day: 'Dia' },
     navLinks: true,
     selectable: true,
     height: 'auto',
     events,
     editable: true,
-    select: info => openNewModal(info.start, info.end),
-    dateClick: info => openNewModal(info.date),
-    eventClick: info => { location.hash = `#orders/${info.event.id}`; },
+    eventContent: info => {
+      const st = info.event.classNames[0];
+      const map = { novo: 'info', em_andamento: 'warning', concluido: 'success', cancelado: 'danger' };
+      return { html: `<span class="badge badge--${map[st]||'info'}">${st}</span> ${esc(info.event.title)}` };
+    },
+    dateClick: info => openSheet(null, info.date),
+    eventClick: info => openSheet(orderMap[info.event.id]),
     eventDrop: async info => {
       const ev = info.event;
       const st = ev.start;
@@ -88,6 +100,13 @@ export const renderAgendaView = async () => {
     }
   });
   calendar.render();
+  const viewSwitch = document.getElementById('agView');
+  viewSwitch.onclick = e => {
+    const btn = e.target.closest('button[data-view]');
+    if (!btn) return;
+    calendar.changeView(btn.dataset.view);
+    viewSwitch.querySelectorAll('button').forEach(b => b.classList.toggle('segmented__item--active', b === btn));
+  };
   const search = document.getElementById('searchAgenda');
   const fromInput = document.getElementById('agFrom');
   const toInput = document.getElementById('agTo');
@@ -108,46 +127,51 @@ export const renderAgendaView = async () => {
   toInput.onchange = applyFilters;
 };
 
-async function openNewModal(start=null, end=null) {
+async function openSheet(order=null, startDate=null) {
   const clients = await getCustomers();
   const servicos = await getServicos();
+  const start = order ? (order.scheduledStart.seconds ? new Date(order.scheduledStart.seconds*1000) : order.scheduledStart) : startDate;
+  const end = order?.scheduledEnd ? (order.scheduledEnd.seconds ? new Date(order.scheduledEnd.seconds*1000) : order.scheduledEnd) : null;
   modalPlaceholder.innerHTML = `
-    <div class="sheet-overlay" id="aOverlay"></div>
     <div class="sheet" id="agendaSheet">
-      <div class="sheet-handle"></div>
-      <h2 class="sheet-title">Novo agendamento</h2>
-      <form id="agenda-form" class="grid">
-        <label>Cliente*
-          <select id="aCustomer" required>
-            <option value="">—</option>
-            ${clients.map(c=>`<option value="${c.id}">${esc(c.name||'-')}</option>`).join('')}
-          </select>
-        </label>
-        <label>Veículo*
-          <select id="aVehicle" required><option value="">—</option></select>
-        </label>
-        <label>Serviço*
-          <select id="aService" required>
-            <option value="">—</option>
-            ${servicos.map(s=>`<option value="${s.id}" data-name="${attr(s.name)}" data-price="${Number(s.price)||0}">${esc(s.name)}</option>`).join('')}
-          </select>
-        </label>
-        <label>Início* <input id="aStart" type="datetime-local" required value="${start?toLocal(start):''}" /></label>
-        <label>Fim <input id="aEnd" type="datetime-local" value="${end?toLocal(end):''}" /></label>
-        <label>Notas <textarea id="aNotes"></textarea></label>
-        <div class="sheet-actions">
-          <button type="button" class="btn btn-ghost" id="aCancel">Cancelar</button>
-          <button class="btn btn-primary">Salvar</button>
-        </div>
-      </form>
+      <div class="sheet__overlay" id="aOverlay"></div>
+      <div class="sheet__panel">
+        <div class="sheet__handle"></div>
+        <h2 class="sheet__title">${order?'Editar agendamento':'Novo agendamento'}</h2>
+        <form id="agenda-form" class="grid">
+          <label>Cliente*
+            <select id="aCustomer" required>
+              <option value="">—</option>
+              ${clients.map(c=>`<option value="${c.id}" ${order?.customerId===c.id?'selected':''}>${esc(c.name||'-')}</option>`).join('')}
+            </select>
+          </label>
+          <label>Veículo*
+            <select id="aVehicle" required><option value="">—</option></select>
+          </label>
+          <label>Serviço*
+            <select id="aService" required>
+              <option value="">—</option>
+              ${servicos.map(s=>`<option value="${s.id}" data-name="${attr(s.name)}" data-price="${Number(s.price)||0}" ${order?.items?.[0]?.servicoId===s.id?'selected':''}>${esc(s.name)}</option>`).join('')}
+            </select>
+          </label>
+          <label>Início* <input id="aStart" type="datetime-local" required value="${start?toLocal(start):''}" /></label>
+          <label>Fim <input id="aEnd" type="datetime-local" value="${end?toLocal(end):''}" /></label>
+          <label>Notas <textarea id="aNotes">${esc(order?.notes||'')}</textarea></label>
+          <div class="sheet__actions">
+            <button type="button" class="btn btn-ghost" id="aCancel">Cancelar</button>
+            <button class="btn btn-primary">Salvar</button>
+          </div>
+        </form>
+      </div>
     </div>
   `;
-  document.getElementById('aCustomer').onchange = async e => {
+  const customerSelect = document.getElementById('aCustomer');
+  customerSelect.onchange = async e => {
     const vs = await getVehiclesForCustomer(e.target.value);
-    document.getElementById('aVehicle').innerHTML =
-      '<option value="">—</option>' + vs.map(v=>`<option value="${v.id}">${esc(v.model||v.plate||'-')}</option>`).join('');
+    document.getElementById('aVehicle').innerHTML = '<option value="">—</option>' + vs.map(v=>`<option value="${v.id}" ${order?.vehicleId===v.id?'selected':''}>${esc(v.model||v.plate||'-')}</option>`).join('');
   };
-  document.getElementById("aOverlay").onclick = closeModal;
+  if(order?.customerId) customerSelect.dispatchEvent(new Event('change'));
+  document.getElementById('aOverlay').onclick = closeModal;
   document.getElementById('aCancel').onclick = closeModal;
   document.getElementById('agenda-form').onsubmit = async e => {
     e.preventDefault();
@@ -158,20 +182,28 @@ async function openNewModal(start=null, end=null) {
       customerId: document.getElementById('aCustomer').value,
       vehicleId: document.getElementById('aVehicle').value,
       items: [item],
-      discount: 0,
+      discount: order?.discount || 0,
       total: item.price,
-      status: 'novo',
+      status: order?.status || 'novo',
       notes: document.getElementById('aNotes').value.trim(),
       scheduledStart: Timestamp.fromDate(new Date(document.getElementById('aStart').value)),
       scheduledEnd: document.getElementById('aEnd').value ? Timestamp.fromDate(new Date(document.getElementById('aEnd').value)) : null
     };
-    const conflict = await hasScheduleConflict({ customerId: data.customerId, vehicleId: data.vehicleId, start: data.scheduledStart.toDate(), end: data.scheduledEnd?.toDate() });
+    const conflict = await hasScheduleConflict({ customerId: data.customerId, vehicleId: data.vehicleId, start: data.scheduledStart.toDate(), end: data.scheduledEnd?.toDate(), excludeOrderId: order?.id });
     if (conflict) { showToast('Conflito de agenda'); return; }
-    const id = await addOrder(data);
+    if (order) {
+      await updateOrder(order.id, data);
+    } else {
+      const id = await addOrder(data);
+      window.dispatchEvent(new Event('orders:changed'));
+      closeModal();
+      renderAgendaView();
+      location.hash = `#orders/${id}`;
+      return;
+    }
     window.dispatchEvent(new Event('orders:changed'));
     closeModal();
     renderAgendaView();
-    location.hash = `#orders/${id}`;
   };
 }
 

--- a/public/js/views/clientesView.js
+++ b/public/js/views/clientesView.js
@@ -66,7 +66,7 @@ export const renderClientesView = async (maybeId) => {
     </div>
 
     <div class="card">
-      <table class="table compact listrada sticky">
+      <table class="table table--compact table--striped sticky">
         <thead><tr><th>Nome</th><th>Telefone</th><th>Email</th><th>Ações</th></tr></thead>
         <tbody id="customers-list"></tbody>
       </table>
@@ -150,7 +150,7 @@ function renderCustomerList() {
 function renderCard(c) {
   return `
     <tr data-id="${c.id}">
-      <td>${esc(c.name || '-')} <span class="badge" data-badge="${c.id}">0</span></td>
+      <td>${esc(c.name || '-')} <span class="badge badge--info" data-badge="${c.id}">0</span></td>
       <td>${esc(c.phone || '-')}</td>
       <td>${esc(c.email || '-')}</td>
       <td>

--- a/public/js/views/dashboardView.js
+++ b/public/js/views/dashboardView.js
@@ -12,20 +12,17 @@ const customerCache = {};
 export async function renderDashboardView() {
   const root = document.getElementById('page-content');
   if (!root) throw new Error('#page-content não encontrado');
+  window.setPageHeader({ title: 'Dashboard' });
   root.innerHTML = `
-  <header class="page-header">
-    <h1 class="page-title">Dashboard</h1>
-    <p class="page-subtitle muted"></p>
-  </header>
   <section class="kpi-grid">
     <div class="kpi-card"><span class="kpi-title">OS Abertas</span><span class="kpi-value">--</span></div>
     <div class="kpi-card"><span class="kpi-title">Hoje</span><span class="kpi-value">--</span></div>
     <div class="kpi-card"><span class="kpi-title">Faturamento</span><span class="kpi-value">--</span></div>
     <div class="kpi-card"><span class="kpi-title">Clientes</span><span class="kpi-value">--</span></div>
   </section>
-  <section>
+  <section class="card mt">
     <h2 class="section-title">Hoje</h2>
-    <div id="dash-today" class="card"></div>
+    <div id="dash-today"></div>
   </section>`;
 
   try {

--- a/public/mobile.css
+++ b/public/mobile.css
@@ -199,11 +199,35 @@ main.main {
 .kpi-title { font-size:12px; color:var(--muted); }
 .kpi-value { font-size:20px; font-weight:600; }
 
-.badge { display:inline-block; padding:2px 8px; border-radius:9999px; font-size:12px; background:var(--line); color:var(--text); }
+/* Bottom Sheet */
+.sheet { position:fixed; inset:0; z-index:120; }
+.sheet__overlay { position:absolute; inset:0; background:rgba(0,0,0,.5); }
+.sheet__panel { position:absolute; left:0; right:0; bottom:0; background:var(--card); border-top-left-radius:16px; border-top-right-radius:16px; padding:16px; max-height:90%; overflow:auto; }
+.sheet__handle { width:40px; height:4px; background:var(--line); border-radius:2px; margin:8px auto; }
+.sheet__title { margin:0 0 16px; text-align:center; font-size:16px; font-weight:600; }
+.sheet__actions { display:flex; justify-content:flex-end; gap:8px; margin-top:16px; }
+@media (prefers-reduced-motion:no-preference){
+  .sheet__overlay{animation:fadeIn .2s;}
+  .sheet__panel{animation:slideUp .2s;}
+}
+@keyframes slideUp{from{transform:translateY(100%);}to{transform:translateY(0);}}
+@keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+
+/* Segmented control */
+.segmented { display:flex; gap:4px; margin-bottom:8px; }
+.segmented__item { flex:1; padding:4px 12px; border-radius:9999px; border:1px solid var(--line); background:var(--card); font-size:14px; }
+.segmented__item--active { background:var(--accent-weak); color:var(--accent); border-color:var(--accent-weak); }
+
+/* Badges */
+.badge { display:inline-block; padding:0 8px; border-radius:9999px; font-size:12px; line-height:20px; }
 .badge--info { background:var(--info); color:#fff; }
 .badge--warning { background:var(--warning); color:#fff; }
 .badge--success { background:var(--success); color:#fff; }
 .badge--danger { background:var(--danger); color:#fff; }
+
+/* Form actions */
+.form-row.actions { justify-content:flex-end; }
+
 .page-header{margin-bottom:16px;}
 .page-title{font-size:22px;font-weight:600;margin:0;}
 .page-subtitle{margin:4px 0 0;font-size:14px;color:var(--muted);}
@@ -211,8 +235,3 @@ main.main {
 .muted{color:var(--muted);}
 .cell__right{display:flex;flex-direction:column;align-items:flex-end;gap:4px;}
 .cell svg.chevron{width:16px;height:16px;color:var(--muted);margin-left:8px;}
-.sheet-overlay{position:fixed;inset:0;background:rgba(0,0,0,.3);backdrop-filter:blur(2px);z-index:90;}
-.sheet{position:fixed;left:0;right:0;bottom:0;background:var(--card);border-top-left-radius:16px;border-top-right-radius:16px;padding:16px;box-shadow:0 -4px 16px rgba(0,0,0,.1);z-index:100;animation:sheetUp .2s ease-out;}
-.sheet-handle{width:40px;height:4px;background:var(--line);border-radius:2px;margin:0 auto 12px;}
-.sheet-actions{display:flex;justify-content:space-between;margin-top:16px;}
-@keyframes sheetUp{from{transform:translateY(100%);}to{transform:translateY(0);}}


### PR DESCRIPTION
## Summary
- localize and streamline calendar with month/day switch and bottom sheet editor
- style orders, clients, and dashboard views for mobile
- add shared mobile styles for sheets, badges and segmented controls

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e8d38dd8c832e901aa17d0c6f4d32