### PR TITLE
refactor: simplify mobile theme

### DIFF
--- a/public/mobile.css
+++ b/public/mobile.css
@@ -11,8 +11,7 @@
   --success:#10B981;
   --danger:#EF4444;
   --radius-card:16px;
-  --radius-btn:12px;
-  --radius-primary:24px;
+  --radius-btn:24px;
   --shadow:0 6px 20px rgba(16,24,40,.06);
   font-size:16px;
 }
@@ -55,15 +54,11 @@ main.main {
   border-radius:var(--radius-btn);
   border:1px solid transparent;
   cursor:pointer;
-  transition:opacity .15s, transform .15s;
 }
-.btn:active {
-  transform:scale(.98);
-}
+.btn:active { transform:scale(.98); }
 .btn-primary {
   background:var(--accent);
   color:#fff;
-  border-radius:var(--radius-primary);
 }
 .btn-secondary {
   background:var(--card);
@@ -75,8 +70,13 @@ main.main {
 .btn-danger {
   background:var(--danger);
   color:#fff;
-  border-radius:var(--radius-primary);
 }
+
+@media (prefers-reduced-motion:no-preference){
+  .btn{transition:opacity .2s,transform .2s;}
+  .tabbar a,.fab{transition:background-color .2s,color .2s;}
+}
+label { display:block; margin-bottom:4px; font-size:14px; }
 .input {
   width:100%;
   height:44px;
@@ -86,8 +86,18 @@ main.main {
   background:var(--card);
   color:var(--text);
 }
-.input:focus {
+.input::placeholder { color:var(--muted); }
+.input[type="file"]{padding:0;} /* exclude file input from height */
+textarea.input{height:auto;min-height:88px;padding:12px;}
+.error { margin-top:4px; font-size:12px; color:var(--danger); }
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
   outline:3px solid var(--accent);
+  outline-offset:2px;
 }
 .tabbar {
   position:fixed;


### PR DESCRIPTION
## Summary
- refine mobile design tokens for light and dark themes
- unify button and input styling with accessible focus rings
- add motion-safe transitions and form feedback styles

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f3f9f7128832eba6de2a4ef6480bf