### PR TITLE
Simplify core views

### DIFF
--- a/public/js/views/clientesView.js
+++ b/public/js/views/clientesView.js
@@ -51,22 +51,16 @@ export const renderClientesView = async (maybeId) => {
     </div>
 
     <div class="card container-md mb-md">
-      <div class="flex gap-sm">
-        <div class="input-icon" style="flex:1;">
-          <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707 1.414-1.414-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z"/>
-          </svg>
-          <input id="search" class="input" type="search" placeholder="Buscar por nome, telefone ou email…" />
-        </div>
-        <select id="sort" class="input">
-          <option value="date">Mais recentes</option>
-          <option value="name">A–Z</option>
-        </select>
+      <div class="input-icon">
+        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707 1.414-1.414-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z"/>
+        </svg>
+        <input id="search" class="input" type="search" placeholder="Buscar por nome, telefone ou email…" />
       </div>
     </div>
 
     <div class="card">
-      <table class="table table--compact table--striped sticky">
+      <table class="table table--compact table--striped">
         <thead><tr><th>Nome</th><th>Telefone</th><th>Email</th><th>Ações</th></tr></thead>
         <tbody id="customers-list"></tbody>
       </table>
@@ -76,7 +70,6 @@ export const renderClientesView = async (maybeId) => {
 
   document.getElementById('form-new-customer').onsubmit = onAddCustomer;
   document.getElementById('search').addEventListener('input', renderCustomerList);
-  document.getElementById('sort').addEventListener('change', renderCustomerList);
   document.getElementById('load-more').onclick = () => loadCustomers();
   document.getElementById('header-new-customer').onclick = () => document.getElementById('cName').focus();
 
@@ -116,23 +109,20 @@ async function loadCustomers(reset = false) {
   lastId = res.lastId;
   customers = customers.concat(res);
   renderCustomerList();
-  document.getElementById('load-more').hidden = !lastId || document.getElementById('sort').value !== 'date';
+  document.getElementById('load-more').hidden = !lastId;
 }
 
 function renderCustomerList() {
   const container = document.getElementById('customers-list');
   const search = document.getElementById('search').value.toLowerCase();
-  const sort = document.getElementById('sort').value;
 
   let list = customers.slice();
   if (search) {
     list = list.filter(c =>
       c.name?.toLowerCase().includes(search) ||
-      c.phone?.toLowerCase().includes(search)
+      c.phone?.toLowerCase().includes(search) ||
+      c.email?.toLowerCase().includes(search)
     );
-  }
-  if (sort === 'name') {
-    list.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
   }
 
   if (!list.length) {

--- a/public/js/views/dashboardView.js
+++ b/public/js/views/dashboardView.js
@@ -53,7 +53,7 @@ export async function renderDashboardView() {
       }
       dashToday.innerHTML = items.join('');
     } else {
-      dashToday.innerHTML = '<p class="muted"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg> Nada hoje</p>'
+      dashToday.innerHTML = '<p class="muted"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg> Nada para hoje</p>'
     }
   } catch (e) {
     console.error(e);

--- a/public/js/views/loginView.js
+++ b/public/js/views/loginView.js
@@ -1,0 +1,31 @@
+// js/views/loginView.js
+export function renderLoginView() {
+  const root = document.getElementById('page-content');
+  if (!root) throw new Error('#page-content não encontrado');
+  root.innerHTML = `
+    <div class="card container-sm">
+      <h1 class="mb">Entrar</h1>
+      <div id="auth-alert" class="alert" aria-live="polite"></div>
+      <div id="tab-login" role="tabpanel">
+        <form id="signin-form" class="grid mt" aria-busy="false">
+          <label for="signin-email">Email</label>
+          <input id="signin-email" class="input" type="email" required />
+          <label for="signin-pass">Senha</label>
+          <input id="signin-pass" class="input" type="password" required />
+          <button class="btn btn-primary mt" style="width:100%;">Entrar</button>
+        </form>
+        <p class="mt-sm"><a id="link-reset" class="link" href="#">Esqueci</a></p>
+      </div>
+      <div id="tab-reset" role="tabpanel" hidden>
+        <form id="reset-form" class="grid mt" aria-busy="false">
+          <label for="reset-email">Email</label>
+          <input id="reset-email" class="input" type="email" required />
+          <div class="form-row actions full">
+            <button type="button" class="link" id="back-to-login">Voltar</button>
+            <button class="btn btn-primary">Enviar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary
- add minimal login view with full-width sign-in form and reset flow
- tidy dashboard today card message
- streamline orders list with search input and BRL totals
- trim clientes view to essential search and list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f41203c60832ea188c90547fe3de3