### PR TITLE
Add MVP website with contact and scheduling forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Brancofilm
 
 Aplicação para gerenciamento de uma oficina de instalação de insufilm.
+Inclui um site simples em HTML/CSS/JS com formulários de contato e agendamento.
 
 ## Desenvolvimento
 
@@ -8,7 +9,7 @@ Aplicação para gerenciamento de uma oficina de instalação de insufilm.
    ```bash
    npm install
    ```
-2. Execute o servidor de desenvolvimento:
+2. Execute o servidor de desenvolvimento e acesse `http://localhost:3000`:
    ```bash
    npm start
    ```

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,45 @@
+document.getElementById('form-agenda').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = Object.fromEntries(new FormData(e.target).entries());
+  try {
+    const res = await fetch('/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    const msg = document.getElementById('agenda-msg');
+    if (res.ok) {
+      msg.textContent = 'Agendamento enviado! Entraremos em contato.';
+      msg.classList.remove('hidden');
+      e.target.reset();
+    } else {
+      msg.textContent = 'Falha ao enviar agendamento.';
+      msg.classList.remove('hidden');
+    }
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('form-contato').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = Object.fromEntries(new FormData(e.target).entries());
+  try {
+    const res = await fetch('/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    const msg = document.getElementById('contato-msg');
+    if (res.ok) {
+      msg.textContent = 'Mensagem enviada!';
+      msg.classList.remove('hidden');
+      e.target.reset();
+    } else {
+      msg.textContent = 'Falha ao enviar mensagem.';
+      msg.classList.remove('hidden');
+    }
+  } catch (err) {
+    console.error(err);
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BrancoFilm - Oficina de Insufilm</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>BrancoFilm</h1>
+    <nav>
+      <a href="#servicos">Serviços</a>
+      <a href="#agenda">Agendamento</a>
+      <a href="#contato">Contato</a>
+    </nav>
+  </header>
+
+  <section id="sobre">
+    <h2>Sobre nós</h2>
+    <p>Especialistas em aplicação de insufilm automotivo com qualidade e garantia.</p>
+  </section>
+
+  <section id="servicos">
+    <h2>Serviços</h2>
+    <ul>
+      <li>Insufilm Automotivo</li>
+      <li>Películas Residenciais</li>
+      <li>Remoção de Insufilm</li>
+    </ul>
+  </section>
+
+  <section id="agenda">
+    <h2>Agende um horário</h2>
+    <form id="form-agenda">
+      <label>Nome:<br /><input type="text" name="nome" required /></label><br />
+      <label>Contato:<br /><input type="text" name="contato" required /></label><br />
+      <label>Modelo do carro:<br /><input type="text" name="modelo" required /></label><br />
+      <label>Tipo de película:<br /><input type="text" name="pelicula" required /></label><br />
+      <label>Data e hora:<br /><input type="datetime-local" name="data" required /></label><br />
+      <button type="submit">Enviar</button>
+    </form>
+    <p id="agenda-msg" class="hidden"></p>
+  </section>
+
+  <section id="contato">
+    <h2>Contato</h2>
+    <form id="form-contato">
+      <label>Nome:<br /><input type="text" name="nome" required /></label><br />
+      <label>E-mail:<br /><input type="email" name="email" required /></label><br />
+      <label>Mensagem:<br /><textarea name="mensagem" required></textarea></label><br />
+      <button type="submit">Enviar</button>
+    </form>
+    <p id="contato-msg" class="hidden"></p>
+  </section>
+
+  <footer>
+    <p>&copy; 2024 BrancoFilm</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,34 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+header nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+section {
+  padding: 2rem;
+}
+
+.hidden {
+  display: none;
+}
+
+footer {
+  background: #f2f2f2;
+  text-align: center;
+  padding: 1rem;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,17 @@ const express = require('express');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.get('/', (req, res) => {
-  res.send('Bem-vindo à oficina de Insufilm!');
+app.use(express.json());
+app.use(express.static('public'));
+
+app.post('/contact', (req, res) => {
+  console.log('Contato recebido:', req.body);
+  res.status(200).send({ message: 'Contato enviado' });
+});
+
+app.post('/schedule', (req, res) => {
+  console.log('Agendamento recebido:', req.body);
+  res.status(200).send({ message: 'Agendamento enviado' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- Add static site with service info, scheduling and contact forms
- Add client-side JavaScript to post form submissions
- Serve static content and handle form endpoints in Express server

## Testing
- `npm test`
- `npm start` and `curl -sS localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68b87836dc78832e812f49aad3b7f5af