### PR TITLE
Add inventory and transaction management dashboard with Firestore

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard - BrancoFilm</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>BrancoFilm Dashboard</h1>
+    <nav>
+      <a href="index.html">Home</a>
+    </nav>
+  </header>
+
+  <section id="summary">
+    <h2>Summary</h2>
+    <div>
+      <h3>Low Stock Items</h3>
+      <ul id="low-stock-list"></ul>
+    </div>
+    <div>
+      <h3>Current Cash Balance</h3>
+      <p id="cash-balance">0</p>
+    </div>
+  </section>
+
+  <section id="inventory">
+    <h2>Inventory</h2>
+    <form id="inventory-form">
+      <input type="text" name="name" placeholder="Name" required />
+      <input type="number" name="quantity" placeholder="Quantity" required />
+      <input type="number" step="0.01" name="cost" placeholder="Cost" required />
+      <input type="number" name="threshold" placeholder="Threshold" required />
+      <button type="submit">Add Item</button>
+    </form>
+    <table id="inventory-list">
+      <thead>
+        <tr><th>Name</th><th>Qty</th><th>Cost</th><th>Threshold</th><th>Actions</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <section id="transactions">
+    <h2>Transactions</h2>
+    <form id="transaction-form">
+      <select name="type">
+        <option value="in">In</option>
+        <option value="out">Out</option>
+      </select>
+      <input type="number" step="0.01" name="amount" placeholder="Amount" required />
+      <input type="date" name="date" required />
+      <input type="text" name="note" placeholder="Note" />
+      <button type="submit">Add Transaction</button>
+    </form>
+    <table id="transaction-list">
+      <thead>
+        <tr><th>Type</th><th>Amount</th><th>Date</th><th>Note</th><th>Actions</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+
+  <script type="module" src="dashboard.js"></script>
+</body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,154 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js';
+import { getFirestore, collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+
+const firebaseConfig = {
+  // TODO: Add your Firebase config
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+const inventoryCol = collection(db, 'inventory');
+const transactionsCol = collection(db, 'transactions');
+
+async function loadInventory() {
+  const snapshot = await getDocs(inventoryCol);
+  const tbody = document.querySelector('#inventory-list tbody');
+  tbody.innerHTML = '';
+  snapshot.forEach((docSnap) => {
+    const data = docSnap.data();
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${data.name}</td>
+      <td>${data.quantity}</td>
+      <td>${data.cost}</td>
+      <td>${data.threshold}</td>
+      <td>
+        <button class="edit" data-id="${docSnap.id}">Edit</button>
+        <button class="delete" data-id="${docSnap.id}">Delete</button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadTransactions() {
+  const snapshot = await getDocs(transactionsCol);
+  const tbody = document.querySelector('#transaction-list tbody');
+  tbody.innerHTML = '';
+  snapshot.forEach((docSnap) => {
+    const data = docSnap.data();
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${data.type}</td>
+      <td>${data.amount}</td>
+      <td>${data.date}</td>
+      <td>${data.note || ''}</td>
+      <td>
+        <button class="edit" data-id="${docSnap.id}">Edit</button>
+        <button class="delete" data-id="${docSnap.id}">Delete</button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('inventory-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const data = {
+    name: form.name.value,
+    quantity: Number(form.quantity.value),
+    cost: Number(form.cost.value),
+    threshold: Number(form.threshold.value)
+  };
+  await addDoc(inventoryCol, data);
+  form.reset();
+  await loadInventory();
+  await updateSummary();
+});
+
+document.getElementById('transaction-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const data = {
+    type: form.type.value,
+    amount: Number(form.amount.value),
+    date: form.date.value,
+    note: form.note.value
+  };
+  await addDoc(transactionsCol, data);
+  form.reset();
+  await loadTransactions();
+  await updateSummary();
+});
+
+document.getElementById('inventory-list').addEventListener('click', async (e) => {
+  if (e.target.classList.contains('delete')) {
+    const id = e.target.dataset.id;
+    await deleteDoc(doc(db, 'inventory', id));
+    await loadInventory();
+    await updateSummary();
+  }
+  if (e.target.classList.contains('edit')) {
+    const id = e.target.dataset.id;
+    const row = e.target.closest('tr');
+    const data = {
+      name: prompt('Name', row.children[0].textContent) || row.children[0].textContent,
+      quantity: Number(prompt('Quantity', row.children[1].textContent) || row.children[1].textContent),
+      cost: Number(prompt('Cost', row.children[2].textContent) || row.children[2].textContent),
+      threshold: Number(prompt('Threshold', row.children[3].textContent) || row.children[3].textContent)
+    };
+    await updateDoc(doc(db, 'inventory', id), data);
+    await loadInventory();
+    await updateSummary();
+  }
+});
+
+document.getElementById('transaction-list').addEventListener('click', async (e) => {
+  if (e.target.classList.contains('delete')) {
+    const id = e.target.dataset.id;
+    await deleteDoc(doc(db, 'transactions', id));
+    await loadTransactions();
+    await updateSummary();
+  }
+  if (e.target.classList.contains('edit')) {
+    const id = e.target.dataset.id;
+    const row = e.target.closest('tr');
+    const data = {
+      type: prompt('Type (in/out)', row.children[0].textContent) || row.children[0].textContent,
+      amount: Number(prompt('Amount', row.children[1].textContent) || row.children[1].textContent),
+      date: prompt('Date', row.children[2].textContent) || row.children[2].textContent,
+      note: prompt('Note', row.children[3].textContent) || row.children[3].textContent
+    };
+    await updateDoc(doc(db, 'transactions', id), data);
+    await loadTransactions();
+    await updateSummary();
+  }
+});
+
+async function updateSummary() {
+  const invSnap = await getDocs(inventoryCol);
+  const lowList = document.getElementById('low-stock-list');
+  lowList.innerHTML = '';
+  invSnap.forEach((docSnap) => {
+    const data = docSnap.data();
+    if (data.quantity <= data.threshold) {
+      const li = document.createElement('li');
+      li.textContent = `${data.name} (${data.quantity})`;
+      lowList.appendChild(li);
+    }
+  });
+
+  const transSnap = await getDocs(transactionsCol);
+  let balance = 0;
+  transSnap.forEach((docSnap) => {
+    const t = docSnap.data();
+    balance += t.type === 'in' ? Number(t.amount) : -Number(t.amount);
+  });
+  document.getElementById('cash-balance').textContent = balance.toFixed(2);
+}
+
+loadInventory();
+loadTransactions();
+updateSummary();

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
       <a href="#servicos">Serviços</a>
       <a href="#agenda">Agendamento</a>
       <a href="#contato">Contato</a>
+      <a href="dashboard.html">Dashboard</a>
     </nav>
   </header>
 

--- a/public/style.css
+++ b/public/style.css
@@ -27,6 +27,21 @@ section {
   display: none;
 }
 
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+table, th, td {
+  border: 1px solid #ccc;
+}
+
+th, td {
+  padding: 0.5rem;
+  text-align: left;
+}
+
 footer {
   background: #f2f2f2;
   text-align: center;


### PR DESCRIPTION
## Summary
- add dashboard page with Firestore-backed inventory and transaction CRUD sections
- show low-stock items and cash balance summary on dashboard landing page
- link dashboard from main site and style tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87af0dc24832e90ae822243e74766